### PR TITLE
fix: Adding Codeowner file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @chibie @OnahProsperity @5ran6will be requested for
+# review when someone opens a pull request.
+*       @chibie @OnahProsperity @sundayonah

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @chibie @OnahProsperity @sundayonah will be requested for
+# @chibie @5ran6 @OnahProsperity will be requested for
 # review when someone opens a pull request.
-*       @chibie @OnahProsperity @sundayonah
+*       @chibie @5ran6 @OnahProsperity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @chibie @OnahProsperity @5ran6will be requested for
+# @chibie @OnahProsperity @sundayonah will be requested for
 # review when someone opens a pull request.
 *       @chibie @OnahProsperity @sundayonah

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://
 > - GitHub Issue/PR number addressed or fixed
 > - StackOverflow post
 > - Support forum thread
-> - Related pull requests/issues from other repos
+> - Related pull requests/issues from other repos e.g #407
 >
 > If there are no references, simply delete this section.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,10 +12,10 @@ By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://
 
 > Include any links supporting this change such as a:
 >
-> - GitHub Issue/PR number addressed or fixed
+> - GitHub Issue/PR number addressed or fixed e.g closes #407
 > - StackOverflow post
 > - Support forum thread
-> - Related pull requests/issues from other repos e.g #407
+> - Related pull requests/issues from other repos
 >
 > If there are no references, simply delete this section.
 


### PR DESCRIPTION
By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).


### Description

> This pull request includes a small change to the `.github/CODEOWNERS` file. The change assigns default owners for the repository and specifies that these owners will be requested for review when a pull request is opened.

* Assigned default owners for the repository: `@chibie`, `@OnahProsperity`, and `@sundayonah`


### References

 `.github/CODEOWNERS` 


### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`