### PR TITLE
Auto-enable early access flag for users in non-production environments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,11 @@
-By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.
+By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
+
 
 ### Description
 
 > Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
 >
 > Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, contracts etc.
->
-> If the UI is being changed, please provide screenshots.
 
 
 ### References
@@ -20,6 +19,7 @@ By submitting a PR to this repository, you agree to the terms within the [Paycre
 >
 > If there are no references, simply delete this section.
 
+
 ### Testing
 
 > Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this project has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
@@ -30,8 +30,9 @@ By submitting a PR to this repository, you agree to the terms within the [Paycre
 
 - [ ] This change adds test coverage for new/changed/fixed functionality
 
+
 ### Checklist
 
-- [ ] I have added documentation for new/changed functionality in this PR
+- [ ] I have added documentation and tests for new/changed functionality in this PR
 - [ ] All active GitHub checks for tests, formatting, and security are passing
-- [ ] The correct base branch is being used, if not `master`
+- [ ] The correct base branch is being used, if not `main`

--- a/config/server.go
+++ b/config/server.go
@@ -19,6 +19,8 @@ type ServerConfiguration struct {
 	CurrenciesCacheDuration   int
 	InstitutionsCacheDuration int
 	PubKeyCacheDuration       int
+	RateLimitUnauthenticated  int
+	RateLimitAuthenticated    int
 }
 
 // ServerConfig sets the server configuration
@@ -33,6 +35,8 @@ func ServerConfig() *ServerConfiguration {
 	viper.SetDefault("CURRENCIES_CACHE_DURATION", 24)
 	viper.SetDefault("INSTITUTIONS_CACHE_DURATION", 24)
 	viper.SetDefault("PUBKEY_CACHE_DURATION", 365)
+	viper.SetDefault("RATE_LIMIT_UNAUTHENTICATED", 5)
+	viper.SetDefault("RATE_LIMIT_AUTHENTICATED", 50)
 
 	return &ServerConfiguration{
 		Debug:                     viper.GetBool("DEBUG"),
@@ -46,6 +50,8 @@ func ServerConfig() *ServerConfiguration {
 		CurrenciesCacheDuration:   viper.GetInt("CURRENCIES_CACHE_DURATION"),
 		InstitutionsCacheDuration: viper.GetInt("INSTITUTIONS_CACHE_DURATION"),
 		PubKeyCacheDuration:       viper.GetInt("PUBKEY_CACHE_DURATION"),
+		RateLimitUnauthenticated:  viper.GetInt("RATE_LIMIT_UNAUTHENTICATED"),
+		RateLimitAuthenticated:    viper.GetInt("RATE_LIMIT_AUTHENTICATED"),
 	}
 }
 

--- a/config/server.go
+++ b/config/server.go
@@ -8,14 +8,17 @@ import (
 
 // ServerConfiguration type defines the server configurations
 type ServerConfiguration struct {
-	Debug        bool
-	Host         string
-	Port         string
-	Timezone     string
-	AllowedHosts string
-	Environment  string
-	SentryDSN    string
-	HostDomain   string
+	Debug                     bool
+	Host                      string
+	Port                      string
+	Timezone                  string
+	AllowedHosts              string
+	Environment               string
+	SentryDSN                 string
+	HostDomain                string
+	CurrenciesCacheDuration   int
+	InstitutionsCacheDuration int
+	PubKeyCacheDuration       int
 }
 
 // ServerConfig sets the server configuration
@@ -27,17 +30,31 @@ func ServerConfig() *ServerConfiguration {
 	viper.SetDefault("ALLOWED_HOSTS", "*")
 	viper.SetDefault("ENVIRONMENT", "local")
 	viper.SetDefault("SENTRY_DSN", "")
+	viper.SetDefault("CURRENCIES_CACHE_DURATION", 24)
+	viper.SetDefault("INSTITUTIONS_CACHE_DURATION", 24)
+	viper.SetDefault("PUBKEY_CACHE_DURATION", 365)
 
 	return &ServerConfiguration{
-		Debug:        viper.GetBool("DEBUG"),
-		Host:         viper.GetString("SERVER_HOST"),
-		Port:         viper.GetString("SERVER_PORT"),
-		Timezone:     viper.GetString("SERVER_TIMEZONE"),
-		AllowedHosts: viper.GetString("ALLOWED_HOSTS"),
-		Environment:  viper.GetString("ENVIRONMENT"),
-		SentryDSN:    viper.GetString("SENTRY_DSN"),
-		HostDomain:   viper.GetString("HOST_DOMAIN"),
+		Debug:                     viper.GetBool("DEBUG"),
+		Host:                      viper.GetString("SERVER_HOST"),
+		Port:                      viper.GetString("SERVER_PORT"),
+		Timezone:                  viper.GetString("SERVER_TIMEZONE"),
+		AllowedHosts:              viper.GetString("ALLOWED_HOSTS"),
+		Environment:               viper.GetString("ENVIRONMENT"),
+		SentryDSN:                 viper.GetString("SENTRY_DSN"),
+		HostDomain:                viper.GetString("HOST_DOMAIN"),
+		CurrenciesCacheDuration:   viper.GetInt("CURRENCIES_CACHE_DURATION"),
+		InstitutionsCacheDuration: viper.GetInt("INSTITUTIONS_CACHE_DURATION"),
+		PubKeyCacheDuration:       viper.GetInt("PUBKEY_CACHE_DURATION"),
 	}
+}
+
+// Reload reinitializes the configuration using the current environment variables
+func Reload() (ServerConfiguration, error) {
+	if err := SetupConfig(); err != nil {
+		return ServerConfiguration{}, fmt.Errorf("config Reload() error: %s", err)
+	}
+	return *ServerConfig(), nil // Return the updated config
 }
 
 func init() {

--- a/controllers/accounts/auth.go
+++ b/controllers/accounts/auth.go
@@ -90,7 +90,7 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 	if serverConf.Environment != "production" {
 		userCreate = userCreate.
 			SetIsEmailVerified(true).
-			SetHasEarlyAccess(true).
+			SetHasEarlyAccess(true)
 	}
 
 	user, err := userCreate.Save(ctx)

--- a/controllers/accounts/auth.go
+++ b/controllers/accounts/auth.go
@@ -86,7 +86,6 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 		SetPassword(payload.Password).
 		SetScope(scope)
 
-	// Checking the environment to set the user as verified and give early access	
 	if serverConf.Environment != "production" {
 		userCreate = userCreate.
 			SetIsEmailVerified(true).
@@ -262,7 +261,7 @@ func (ctrl *AuthController) Login(ctx *gin.Context) {
 
 	// Check if user has early access
 	environment := serverConf.Environment
-	if !user.HasEarlyAccess && (environment == "production") {
+	if !user.HasEarlyAccess && (environment == "production" || environment == "staging") {
 		u.APIResponse(ctx, http.StatusUnauthorized, "error",
 			"Your early access request is still pending", nil,
 		)

--- a/controllers/accounts/auth.go
+++ b/controllers/accounts/auth.go
@@ -86,9 +86,11 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 		SetPassword(payload.Password).
 		SetScope(scope)
 
+	// Checking the environment to set the user as verified and give early access	
 	if serverConf.Environment != "production" {
 		userCreate = userCreate.
-			SetIsEmailVerified(true)
+			SetIsEmailVerified(true).
+			SetHasEarlyAccess(true).
 	}
 
 	user, err := userCreate.Save(ctx)
@@ -260,7 +262,7 @@ func (ctrl *AuthController) Login(ctx *gin.Context) {
 
 	// Check if user has early access
 	environment := serverConf.Environment
-	if !user.HasEarlyAccess && (environment == "production" || environment == "staging") {
+	if !user.HasEarlyAccess && (environment == "production") {
 		u.APIResponse(ctx, http.StatusUnauthorized, "error",
 			"Your early access request is still pending", nil,
 		)

--- a/controllers/accounts/auth_test.go
+++ b/controllers/accounts/auth_test.go
@@ -464,14 +464,11 @@ func TestAuth(t *testing.T) {
 				t.Run(tt.name, func(t *testing.T) {
 					// Set the environment variable
 					os.Setenv("ENVIRONMENT", tt.environment)
-					// fmt.Println("Environment before reload:", os.Getenv("ENVIRONMENT"))
 
 					// Reload and update serverConf correctly
 					newConf, err := config.Reload()
 					assert.NoError(t, err)
 					serverConf := &newConf // Assign pointer to new config
-
-					// fmt.Println("Environment after reload:", serverConf.Environment)
 
 					// Create user with the appropriate HasEarlyAccess value based on the environment
 					ctx := context.Background()

--- a/controllers/accounts/auth_test.go
+++ b/controllers/accounts/auth_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/jarcoal/httpmock"
@@ -29,6 +30,7 @@ import (
 	"github.com/paycrest/aggregator/utils/test"
 	"github.com/paycrest/aggregator/utils/token"
 	"github.com/stretchr/testify/assert"
+	"github.com/paycrest/aggregator/config"
 )
 
 func TestAuth(t *testing.T) {

--- a/controllers/accounts/auth_test.go
+++ b/controllers/accounts/auth_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
-	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/jarcoal/httpmock"
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/gin-gonic/gin"
+	"github.com/paycrest/aggregator/config"
 	"github.com/paycrest/aggregator/ent/enttest"
 	userEnt "github.com/paycrest/aggregator/ent/user"
 	"github.com/paycrest/aggregator/ent/verificationtoken"
@@ -30,7 +31,6 @@ import (
 	"github.com/paycrest/aggregator/utils/test"
 	"github.com/paycrest/aggregator/utils/token"
 	"github.com/stretchr/testify/assert"
-	"github.com/paycrest/aggregator/config"
 )
 
 func TestAuth(t *testing.T) {
@@ -470,11 +470,12 @@ func TestAuth(t *testing.T) {
 						SetLastName("User").
 						SetEmail(fmt.Sprintf("test-%s@example.com", tt.environment)).
 						SetPassword("password").
+						SetScope("sender").
 						Save(ctx)
 					assert.NoError(t, err)
 	
 					// Check the HasEarlyAccess field
-					assert.Equal(t, tt.expectedEarlyAccess, user.HasEarlyAccess)
+					assert.Equal(t, tt.expectedEarlyAccess, user.HasEarlyAccess, "unexpected HasEarlyAccess for environment %s", tt.environment)
 	
 					// Cleanup
 					err = client.User.DeleteOne(user).Exec(ctx)

--- a/ent/schema/user.go
+++ b/ent/schema/user.go
@@ -39,7 +39,7 @@ func (User) Fields() []ent.Field {
 		field.String("scope"),
 		field.Bool("is_email_verified").
 			Default(false),
-		field.Bool("has_early_access").
+		field.Bool("has_early_access"). // has_early_access is "false" by default
 			Default(false),
 	}
 }


### PR DESCRIPTION
Automatically sets the `has_early_access` flag to true when creating new users in non-production environments, while maintaining the default false value in production. 
This change simplifies testing of early access features in development and staging environments by eliminating the need for manual database updates.

## Changes
- Modified user creation logic in Register controller to conditionally set `has_early_access`
- Updated user creation builder to set `has_early_access` to true in non-production
- Added test coverage in auth_test.go to verify the behavior

## Testing
- Verified new user registration sets `has_early_access=true` in development
- Verified new user registration keeps `has_early_access=false` in production
- Added unit tests to cover both scenarios
- Manual testing completed in development environment