### PR TITLE
Restrict orders to enabled networks

### DIFF
--- a/controllers/sender/sender.go
+++ b/controllers/sender/sender.go
@@ -89,7 +89,6 @@ func (ctrl *SenderController) InitiatePaymentOrder(ctx *gin.Context) {
 				Message: "Provided token is not supported",
 			})
 		} else {
-			// log.Errorf("Database error while validating token", err)
 			u.APIResponse(ctx, http.StatusInternalServerError, "error", "Internal server error", nil)
 		}
 		return

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -218,6 +218,7 @@ var (
 		{Name: "gateway_contract_address", Type: field.TypeString, Default: ""},
 		{Name: "is_testnet", Type: field.TypeBool},
 		{Name: "fee", Type: field.TypeFloat64},
+		{Name: "is_enabled", Type: field.TypeBool, Default: false},
 	}
 	// NetworksTable holds the schema information for the "networks" table.
 	NetworksTable = &schema.Table{

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -6455,6 +6455,7 @@ type NetworkMutation struct {
 	is_testnet               *bool
 	fee                      *decimal.Decimal
 	addfee                   *decimal.Decimal
+	is_enabled               *bool
 	clearedFields            map[string]struct{}
 	tokens                   map[int]struct{}
 	removedtokens            map[int]struct{}
@@ -6939,6 +6940,42 @@ func (m *NetworkMutation) ResetFee() {
 	m.addfee = nil
 }
 
+// SetIsEnabled sets the "is_enabled" field.
+func (m *NetworkMutation) SetIsEnabled(b bool) {
+	m.is_enabled = &b
+}
+
+// IsEnabled returns the value of the "is_enabled" field in the mutation.
+func (m *NetworkMutation) IsEnabled() (r bool, exists bool) {
+	v := m.is_enabled
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldIsEnabled returns the old "is_enabled" field's value of the Network entity.
+// If the Network object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *NetworkMutation) OldIsEnabled(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldIsEnabled is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldIsEnabled requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldIsEnabled: %w", err)
+	}
+	return oldValue.IsEnabled, nil
+}
+
+// ResetIsEnabled resets all changes to the "is_enabled" field.
+func (m *NetworkMutation) ResetIsEnabled() {
+	m.is_enabled = nil
+}
+
 // AddTokenIDs adds the "tokens" edge to the Token entity by ids.
 func (m *NetworkMutation) AddTokenIDs(ids ...int) {
 	if m.tokens == nil {
@@ -7027,7 +7064,7 @@ func (m *NetworkMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *NetworkMutation) Fields() []string {
-	fields := make([]string, 0, 9)
+	fields := make([]string, 0, 10)
 	if m.created_at != nil {
 		fields = append(fields, network.FieldCreatedAt)
 	}
@@ -7055,6 +7092,9 @@ func (m *NetworkMutation) Fields() []string {
 	if m.fee != nil {
 		fields = append(fields, network.FieldFee)
 	}
+	if m.is_enabled != nil {
+		fields = append(fields, network.FieldIsEnabled)
+	}
 	return fields
 }
 
@@ -7081,6 +7121,8 @@ func (m *NetworkMutation) Field(name string) (ent.Value, bool) {
 		return m.IsTestnet()
 	case network.FieldFee:
 		return m.Fee()
+	case network.FieldIsEnabled:
+		return m.IsEnabled()
 	}
 	return nil, false
 }
@@ -7108,6 +7150,8 @@ func (m *NetworkMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldIsTestnet(ctx)
 	case network.FieldFee:
 		return m.OldFee(ctx)
+	case network.FieldIsEnabled:
+		return m.OldIsEnabled(ctx)
 	}
 	return nil, fmt.Errorf("unknown Network field %s", name)
 }
@@ -7179,6 +7223,13 @@ func (m *NetworkMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetFee(v)
+		return nil
+	case network.FieldIsEnabled:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetIsEnabled(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Network field %s", name)
@@ -7291,6 +7342,9 @@ func (m *NetworkMutation) ResetField(name string) error {
 		return nil
 	case network.FieldFee:
 		m.ResetFee()
+		return nil
+	case network.FieldIsEnabled:
+		m.ResetIsEnabled()
 		return nil
 	}
 	return fmt.Errorf("unknown Network field %s", name)

--- a/ent/network.go
+++ b/ent/network.go
@@ -36,6 +36,8 @@ type Network struct {
 	IsTestnet bool `json:"is_testnet,omitempty"`
 	// Fee holds the value of the "fee" field.
 	Fee decimal.Decimal `json:"fee,omitempty"`
+	// IsEnabled holds the value of the "is_enabled" field.
+	IsEnabled bool `json:"is_enabled,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the NetworkQuery when eager-loading is set.
 	Edges        NetworkEdges `json:"edges"`
@@ -67,7 +69,7 @@ func (*Network) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case network.FieldFee:
 			values[i] = new(decimal.Decimal)
-		case network.FieldIsTestnet:
+		case network.FieldIsTestnet, network.FieldIsEnabled:
 			values[i] = new(sql.NullBool)
 		case network.FieldID, network.FieldChainID:
 			values[i] = new(sql.NullInt64)
@@ -150,6 +152,12 @@ func (n *Network) assignValues(columns []string, values []any) error {
 			} else if value != nil {
 				n.Fee = *value
 			}
+		case network.FieldIsEnabled:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field is_enabled", values[i])
+			} else if value.Valid {
+				n.IsEnabled = value.Bool
+			}
 		default:
 			n.selectValues.Set(columns[i], values[i])
 		}
@@ -217,6 +225,9 @@ func (n *Network) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("fee=")
 	builder.WriteString(fmt.Sprintf("%v", n.Fee))
+	builder.WriteString(", ")
+	builder.WriteString("is_enabled=")
+	builder.WriteString(fmt.Sprintf("%v", n.IsEnabled))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/network/network.go
+++ b/ent/network/network.go
@@ -32,6 +32,8 @@ const (
 	FieldIsTestnet = "is_testnet"
 	// FieldFee holds the string denoting the fee field in the database.
 	FieldFee = "fee"
+	// FieldIsEnabled holds the string denoting the is_enabled field in the database.
+	FieldIsEnabled = "is_enabled"
 	// EdgeTokens holds the string denoting the tokens edge name in mutations.
 	EdgeTokens = "tokens"
 	// Table holds the table name of the network in the database.
@@ -57,6 +59,7 @@ var Columns = []string{
 	FieldGatewayContractAddress,
 	FieldIsTestnet,
 	FieldFee,
+	FieldIsEnabled,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -78,6 +81,8 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 	// DefaultGatewayContractAddress holds the default value on creation for the "gateway_contract_address" field.
 	DefaultGatewayContractAddress string
+	// DefaultIsEnabled holds the default value on creation for the "is_enabled" field.
+	DefaultIsEnabled bool
 )
 
 // OrderOption defines the ordering options for the Network queries.
@@ -131,6 +136,11 @@ func ByIsTestnet(opts ...sql.OrderTermOption) OrderOption {
 // ByFee orders the results by the fee field.
 func ByFee(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldFee, opts...).ToFunc()
+}
+
+// ByIsEnabled orders the results by the is_enabled field.
+func ByIsEnabled(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldIsEnabled, opts...).ToFunc()
 }
 
 // ByTokensCount orders the results by tokens count.

--- a/ent/network/where.go
+++ b/ent/network/where.go
@@ -101,6 +101,11 @@ func Fee(v decimal.Decimal) predicate.Network {
 	return predicate.Network(sql.FieldEQ(FieldFee, v))
 }
 
+// IsEnabled applies equality check predicate on the "is_enabled" field. It's identical to IsEnabledEQ.
+func IsEnabled(v bool) predicate.Network {
+	return predicate.Network(sql.FieldEQ(FieldIsEnabled, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Network {
 	return predicate.Network(sql.FieldEQ(FieldCreatedAt, v))
@@ -539,6 +544,16 @@ func FeeLT(v decimal.Decimal) predicate.Network {
 // FeeLTE applies the LTE predicate on the "fee" field.
 func FeeLTE(v decimal.Decimal) predicate.Network {
 	return predicate.Network(sql.FieldLTE(FieldFee, v))
+}
+
+// IsEnabledEQ applies the EQ predicate on the "is_enabled" field.
+func IsEnabledEQ(v bool) predicate.Network {
+	return predicate.Network(sql.FieldEQ(FieldIsEnabled, v))
+}
+
+// IsEnabledNEQ applies the NEQ predicate on the "is_enabled" field.
+func IsEnabledNEQ(v bool) predicate.Network {
+	return predicate.Network(sql.FieldNEQ(FieldIsEnabled, v))
 }
 
 // HasTokens applies the HasEdge predicate on the "tokens" edge.

--- a/ent/network_create.go
+++ b/ent/network_create.go
@@ -110,6 +110,20 @@ func (nc *NetworkCreate) SetFee(d decimal.Decimal) *NetworkCreate {
 	return nc
 }
 
+// SetIsEnabled sets the "is_enabled" field.
+func (nc *NetworkCreate) SetIsEnabled(b bool) *NetworkCreate {
+	nc.mutation.SetIsEnabled(b)
+	return nc
+}
+
+// SetNillableIsEnabled sets the "is_enabled" field if the given value is not nil.
+func (nc *NetworkCreate) SetNillableIsEnabled(b *bool) *NetworkCreate {
+	if b != nil {
+		nc.SetIsEnabled(*b)
+	}
+	return nc
+}
+
 // AddTokenIDs adds the "tokens" edge to the Token entity by IDs.
 func (nc *NetworkCreate) AddTokenIDs(ids ...int) *NetworkCreate {
 	nc.mutation.AddTokenIDs(ids...)
@@ -172,6 +186,10 @@ func (nc *NetworkCreate) defaults() {
 		v := network.DefaultGatewayContractAddress
 		nc.mutation.SetGatewayContractAddress(v)
 	}
+	if _, ok := nc.mutation.IsEnabled(); !ok {
+		v := network.DefaultIsEnabled
+		nc.mutation.SetIsEnabled(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -199,6 +217,9 @@ func (nc *NetworkCreate) check() error {
 	}
 	if _, ok := nc.mutation.Fee(); !ok {
 		return &ValidationError{Name: "fee", err: errors.New(`ent: missing required field "Network.fee"`)}
+	}
+	if _, ok := nc.mutation.IsEnabled(); !ok {
+		return &ValidationError{Name: "is_enabled", err: errors.New(`ent: missing required field "Network.is_enabled"`)}
 	}
 	return nil
 }
@@ -262,6 +283,10 @@ func (nc *NetworkCreate) createSpec() (*Network, *sqlgraph.CreateSpec) {
 	if value, ok := nc.mutation.Fee(); ok {
 		_spec.SetField(network.FieldFee, field.TypeFloat64, value)
 		_node.Fee = value
+	}
+	if value, ok := nc.mutation.IsEnabled(); ok {
+		_spec.SetField(network.FieldIsEnabled, field.TypeBool, value)
+		_node.IsEnabled = value
 	}
 	if nodes := nc.mutation.TokensIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -445,6 +470,18 @@ func (u *NetworkUpsert) AddFee(v decimal.Decimal) *NetworkUpsert {
 	return u
 }
 
+// SetIsEnabled sets the "is_enabled" field.
+func (u *NetworkUpsert) SetIsEnabled(v bool) *NetworkUpsert {
+	u.Set(network.FieldIsEnabled, v)
+	return u
+}
+
+// UpdateIsEnabled sets the "is_enabled" field to the value that was provided on create.
+func (u *NetworkUpsert) UpdateIsEnabled() *NetworkUpsert {
+	u.SetExcluded(network.FieldIsEnabled)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -620,6 +657,20 @@ func (u *NetworkUpsertOne) AddFee(v decimal.Decimal) *NetworkUpsertOne {
 func (u *NetworkUpsertOne) UpdateFee() *NetworkUpsertOne {
 	return u.Update(func(s *NetworkUpsert) {
 		s.UpdateFee()
+	})
+}
+
+// SetIsEnabled sets the "is_enabled" field.
+func (u *NetworkUpsertOne) SetIsEnabled(v bool) *NetworkUpsertOne {
+	return u.Update(func(s *NetworkUpsert) {
+		s.SetIsEnabled(v)
+	})
+}
+
+// UpdateIsEnabled sets the "is_enabled" field to the value that was provided on create.
+func (u *NetworkUpsertOne) UpdateIsEnabled() *NetworkUpsertOne {
+	return u.Update(func(s *NetworkUpsert) {
+		s.UpdateIsEnabled()
 	})
 }
 
@@ -964,6 +1015,20 @@ func (u *NetworkUpsertBulk) AddFee(v decimal.Decimal) *NetworkUpsertBulk {
 func (u *NetworkUpsertBulk) UpdateFee() *NetworkUpsertBulk {
 	return u.Update(func(s *NetworkUpsert) {
 		s.UpdateFee()
+	})
+}
+
+// SetIsEnabled sets the "is_enabled" field.
+func (u *NetworkUpsertBulk) SetIsEnabled(v bool) *NetworkUpsertBulk {
+	return u.Update(func(s *NetworkUpsert) {
+		s.SetIsEnabled(v)
+	})
+}
+
+// UpdateIsEnabled sets the "is_enabled" field to the value that was provided on create.
+func (u *NetworkUpsertBulk) UpdateIsEnabled() *NetworkUpsertBulk {
+	return u.Update(func(s *NetworkUpsert) {
+		s.UpdateIsEnabled()
 	})
 }
 

--- a/ent/network_update.go
+++ b/ent/network_update.go
@@ -154,6 +154,20 @@ func (nu *NetworkUpdate) AddFee(d decimal.Decimal) *NetworkUpdate {
 	return nu
 }
 
+// SetIsEnabled sets the "is_enabled" field.
+func (nu *NetworkUpdate) SetIsEnabled(b bool) *NetworkUpdate {
+	nu.mutation.SetIsEnabled(b)
+	return nu
+}
+
+// SetNillableIsEnabled sets the "is_enabled" field if the given value is not nil.
+func (nu *NetworkUpdate) SetNillableIsEnabled(b *bool) *NetworkUpdate {
+	if b != nil {
+		nu.SetIsEnabled(*b)
+	}
+	return nu
+}
+
 // AddTokenIDs adds the "tokens" edge to the Token entity by IDs.
 func (nu *NetworkUpdate) AddTokenIDs(ids ...int) *NetworkUpdate {
 	nu.mutation.AddTokenIDs(ids...)
@@ -272,6 +286,9 @@ func (nu *NetworkUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := nu.mutation.AddedFee(); ok {
 		_spec.AddField(network.FieldFee, field.TypeFloat64, value)
+	}
+	if value, ok := nu.mutation.IsEnabled(); ok {
+		_spec.SetField(network.FieldIsEnabled, field.TypeBool, value)
 	}
 	if nu.mutation.TokensCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -462,6 +479,20 @@ func (nuo *NetworkUpdateOne) AddFee(d decimal.Decimal) *NetworkUpdateOne {
 	return nuo
 }
 
+// SetIsEnabled sets the "is_enabled" field.
+func (nuo *NetworkUpdateOne) SetIsEnabled(b bool) *NetworkUpdateOne {
+	nuo.mutation.SetIsEnabled(b)
+	return nuo
+}
+
+// SetNillableIsEnabled sets the "is_enabled" field if the given value is not nil.
+func (nuo *NetworkUpdateOne) SetNillableIsEnabled(b *bool) *NetworkUpdateOne {
+	if b != nil {
+		nuo.SetIsEnabled(*b)
+	}
+	return nuo
+}
+
 // AddTokenIDs adds the "tokens" edge to the Token entity by IDs.
 func (nuo *NetworkUpdateOne) AddTokenIDs(ids ...int) *NetworkUpdateOne {
 	nuo.mutation.AddTokenIDs(ids...)
@@ -610,6 +641,9 @@ func (nuo *NetworkUpdateOne) sqlSave(ctx context.Context) (_node *Network, err e
 	}
 	if value, ok := nuo.mutation.AddedFee(); ok {
 		_spec.AddField(network.FieldFee, field.TypeFloat64, value)
+	}
+	if value, ok := nuo.mutation.IsEnabled(); ok {
+		_spec.SetField(network.FieldIsEnabled, field.TypeBool, value)
 	}
 	if nuo.mutation.TokensCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/runtime/runtime.go
+++ b/ent/runtime/runtime.go
@@ -194,6 +194,10 @@ func init() {
 	networkDescGatewayContractAddress := networkFields[4].Descriptor()
 	// network.DefaultGatewayContractAddress holds the default value on creation for the gateway_contract_address field.
 	network.DefaultGatewayContractAddress = networkDescGatewayContractAddress.Default.(string)
+	// networkDescIsEnabled is the schema descriptor for is_enabled field.
+	networkDescIsEnabled := networkFields[7].Descriptor()
+	// network.DefaultIsEnabled holds the default value on creation for the is_enabled field.
+	network.DefaultIsEnabled = networkDescIsEnabled.Default.(bool)
 	paymentorderMixin := schema.PaymentOrder{}.Mixin()
 	paymentorderMixinFields0 := paymentorderMixin[0].Fields()
 	_ = paymentorderMixinFields0

--- a/ent/schema/network.go
+++ b/ent/schema/network.go
@@ -33,6 +33,7 @@ func (Network) Fields() []ent.Field {
 		field.Bool("is_testnet"),
 		field.Float("fee").
 			GoType(decimal.Decimal{}),
+		field.Bool("is_enabled").Default(false),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/spf13/viper v1.16.0
 	github.com/stackup-wallet/stackup-bundler v0.6.30
 	github.com/stretchr/testify v1.8.4
+	google.golang.org/appengine v1.6.7
 	google.golang.org/grpc v1.55.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -934,6 +934,7 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180518175338-11a468237815/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -54,7 +54,10 @@ func setRPCClients(ctx context.Context) ([]*ent.Network, error) {
 
 	networks, err := storage.Client.Network.
 		Query().
-		Where(networkent.IsTestnetEQ(isTestnet)).
+		Where(
+			networkent.IsTestnetEQ(isTestnet),
+			networkent.IsEnabledEQ(true),
+		).
 		All(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("setRPCClients.fetchNetworks: %w", err)


### PR DESCRIPTION
### Description

This PR ensures that payments can only be initiated for networks that are actively supported by introducing an is_enabled field to the network table. This change prevents payments on disabled networks and restricts the system to only fetch and use enabled networks.

### Key Changes:
  * Added is_enabled field to the network table with a default value of false.
  * Updated the Network entity schema to include is_enabled.
  * Modified setRPCClients to fetch and use only enabled networks.
  * Implemented validation in POST /sender/orders to prevent payments on disabled networks.
  * Ensured new networks default to is_enabled = false if not explicitly set.



### References

closes #422


### Testing

- [ ] Test that payments are blocked for disabled networks.
- [ ] Test that setRPCClients only fetches and connects to enabled networks.
- [ ] Test that the is_enabled field defaults to false for new networks.
 

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`

