### PR TITLE
feat: add base currency support for tokens and rate calculations

### DIFF
--- a/controllers/index.go
+++ b/controllers/index.go
@@ -132,7 +132,7 @@ func (ctrl *Controller) GetTokenRate(ctx *gin.Context) {
 	}
 
 	if token == nil {
-		u.APIResponse(ctx, http.StatusBadRequest, "error", "Token is not supported", nil)
+		u.APIResponse(ctx, http.StatusBadRequest, "error", fmt.Sprintf("Token %s is not supported", strings.ToUpper(ctx.Param("token"))), nil)
 		return
 	}
 
@@ -145,7 +145,12 @@ func (ctrl *Controller) GetTokenRate(ctx *gin.Context) {
 		Only(ctx)
 	if err != nil {
 		logger.Errorf("error: %v", err)
-		u.APIResponse(ctx, http.StatusBadRequest, "error", "Fiat currency is not supported", nil)
+		u.APIResponse(ctx, http.StatusBadRequest, "error", fmt.Sprintf("Fiat currency %s is not supported", strings.ToUpper(ctx.Param("fiat"))), nil)
+		return
+	}
+
+	if !strings.EqualFold(token.BaseCurrency, currency.Code) && !strings.EqualFold(token.BaseCurrency, "USD") {
+		u.APIResponse(ctx, http.StatusBadRequest, "error", fmt.Sprintf("%s can only be converted to %s", token.Symbol, token.BaseCurrency), nil)
 		return
 	}
 

--- a/controllers/provider/provider.go
+++ b/controllers/provider/provider.go
@@ -649,7 +649,7 @@ func (ctrl *ProviderController) GetMarketRate(ctx *gin.Context) {
 	}
 
 	if tokenObj == nil {
-		u.APIResponse(ctx, http.StatusBadRequest, "error", "Token is not supported", nil)
+		u.APIResponse(ctx, http.StatusBadRequest, "error", fmt.Sprintf("Token %s is not supported", strings.ToUpper(ctx.Param("token"))), nil)
 		return
 	}
 
@@ -662,7 +662,12 @@ func (ctrl *ProviderController) GetMarketRate(ctx *gin.Context) {
 		Only(ctx)
 	if err != nil {
 		logger.Errorf("error: %v", err)
-		u.APIResponse(ctx, http.StatusBadRequest, "error", "Fiat currency is not supported", nil)
+		u.APIResponse(ctx, http.StatusBadRequest, "error", fmt.Sprintf("Fiat currency %s is not supported", strings.ToUpper(ctx.Param("fiat"))), nil)
+		return
+	}
+
+	if !strings.EqualFold(tokenObj.BaseCurrency, currency.Code) && !strings.EqualFold(tokenObj.BaseCurrency, "USD") {
+		u.APIResponse(ctx, http.StatusBadRequest, "error", fmt.Sprintf("%s can only be converted to %s", tokenObj.Symbol, tokenObj.BaseCurrency), nil)
 		return
 	}
 

--- a/controllers/provider/provider.go
+++ b/controllers/provider/provider.go
@@ -643,13 +643,12 @@ func (ctrl *ProviderController) GetMarketRate(ctx *gin.Context) {
 		).
 		First(ctx)
 	if err != nil {
+		if ent.IsNotFound(err) {
+			u.APIResponse(ctx, http.StatusBadRequest, "error", fmt.Sprintf("Token %s is not supported", strings.ToUpper(ctx.Param("token"))), nil)
+			return
+		}
 		logger.Errorf("error: %v", err)
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to get market rate", nil)
-		return
-	}
-
-	if tokenObj == nil {
-		u.APIResponse(ctx, http.StatusBadRequest, "error", fmt.Sprintf("Token %s is not supported", strings.ToUpper(ctx.Param("token"))), nil)
 		return
 	}
 

--- a/controllers/provider/provider_test.go
+++ b/controllers/provider/provider_test.go
@@ -599,7 +599,7 @@ func TestProvider(t *testing.T) {
 			var response types.Response
 			err = json.Unmarshal(res.Body.Bytes(), &response)
 			assert.NoError(t, err)
-			assert.Equal(t, "Token is not supported", response.Message)
+			assert.Equal(t, "Token XXXX is not supported", response.Message)
 		})
 
 		t.Run("when fiat does not exist", func(t *testing.T) {
@@ -624,7 +624,7 @@ func TestProvider(t *testing.T) {
 			var response types.Response
 			err = json.Unmarshal(res.Body.Bytes(), &response)
 			assert.NoError(t, err)
-			assert.Equal(t, "Fiat currency is not supported", response.Message)
+			assert.Equal(t, "Fiat currency USD is not supported", response.Message)
 		})
 
 		t.Run("when fiat exist", func(t *testing.T) {

--- a/controllers/sender/sender.go
+++ b/controllers/sender/sender.go
@@ -1,6 +1,7 @@
 package sender
 
 import (
+	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
@@ -228,6 +229,11 @@ func (ctrl *SenderController) InitiatePaymentOrder(ctx *gin.Context) {
 			Field:   "Recipient",
 			Message: "Invalid institution code provided",
 		})
+		return
+	}
+
+	if !strings.EqualFold(token.BaseCurrency, institutionObj.Edges.FiatCurrency.Code) && !strings.EqualFold(token.BaseCurrency, "USD") {
+		u.APIResponse(ctx, http.StatusBadRequest, "error", fmt.Sprintf("%s can only be converted to %s", token.Symbol, token.BaseCurrency), nil)
 		return
 	}
 

--- a/ent/lockorderfulfillment/where.go
+++ b/ent/lockorderfulfillment/where.go
@@ -216,6 +216,16 @@ func TxIDHasSuffix(v string) predicate.LockOrderFulfillment {
 	return predicate.LockOrderFulfillment(sql.FieldHasSuffix(FieldTxID, v))
 }
 
+// TxIDIsNil applies the IsNil predicate on the "tx_id" field.
+func TxIDIsNil() predicate.LockOrderFulfillment {
+	return predicate.LockOrderFulfillment(sql.FieldIsNull(FieldTxID))
+}
+
+// TxIDNotNil applies the NotNil predicate on the "tx_id" field.
+func TxIDNotNil() predicate.LockOrderFulfillment {
+	return predicate.LockOrderFulfillment(sql.FieldNotNull(FieldTxID))
+}
+
 // TxIDEqualFold applies the EqualFold predicate on the "tx_id" field.
 func TxIDEqualFold(v string) predicate.LockOrderFulfillment {
 	return predicate.LockOrderFulfillment(sql.FieldEqualFold(FieldTxID, v))

--- a/ent/lockorderfulfillment_create.go
+++ b/ent/lockorderfulfillment_create.go
@@ -59,6 +59,14 @@ func (lofc *LockOrderFulfillmentCreate) SetTxID(s string) *LockOrderFulfillmentC
 	return lofc
 }
 
+// SetNillableTxID sets the "tx_id" field if the given value is not nil.
+func (lofc *LockOrderFulfillmentCreate) SetNillableTxID(s *string) *LockOrderFulfillmentCreate {
+	if s != nil {
+		lofc.SetTxID(*s)
+	}
+	return lofc
+}
+
 // SetPsp sets the "psp" field.
 func (lofc *LockOrderFulfillmentCreate) SetPsp(s string) *LockOrderFulfillmentCreate {
 	lofc.mutation.SetPsp(s)
@@ -186,9 +194,6 @@ func (lofc *LockOrderFulfillmentCreate) check() error {
 	}
 	if _, ok := lofc.mutation.UpdatedAt(); !ok {
 		return &ValidationError{Name: "updated_at", err: errors.New(`ent: missing required field "LockOrderFulfillment.updated_at"`)}
-	}
-	if _, ok := lofc.mutation.TxID(); !ok {
-		return &ValidationError{Name: "tx_id", err: errors.New(`ent: missing required field "LockOrderFulfillment.tx_id"`)}
 	}
 	if _, ok := lofc.mutation.ValidationStatus(); !ok {
 		return &ValidationError{Name: "validation_status", err: errors.New(`ent: missing required field "LockOrderFulfillment.validation_status"`)}
@@ -354,6 +359,12 @@ func (u *LockOrderFulfillmentUpsert) UpdateTxID() *LockOrderFulfillmentUpsert {
 	return u
 }
 
+// ClearTxID clears the value of the "tx_id" field.
+func (u *LockOrderFulfillmentUpsert) ClearTxID() *LockOrderFulfillmentUpsert {
+	u.SetNull(lockorderfulfillment.FieldTxID)
+	return u
+}
+
 // SetPsp sets the "psp" field.
 func (u *LockOrderFulfillmentUpsert) SetPsp(v string) *LockOrderFulfillmentUpsert {
 	u.Set(lockorderfulfillment.FieldPsp, v)
@@ -478,6 +489,13 @@ func (u *LockOrderFulfillmentUpsertOne) SetTxID(v string) *LockOrderFulfillmentU
 func (u *LockOrderFulfillmentUpsertOne) UpdateTxID() *LockOrderFulfillmentUpsertOne {
 	return u.Update(func(s *LockOrderFulfillmentUpsert) {
 		s.UpdateTxID()
+	})
+}
+
+// ClearTxID clears the value of the "tx_id" field.
+func (u *LockOrderFulfillmentUpsertOne) ClearTxID() *LockOrderFulfillmentUpsertOne {
+	return u.Update(func(s *LockOrderFulfillmentUpsert) {
+		s.ClearTxID()
 	})
 }
 
@@ -780,6 +798,13 @@ func (u *LockOrderFulfillmentUpsertBulk) SetTxID(v string) *LockOrderFulfillment
 func (u *LockOrderFulfillmentUpsertBulk) UpdateTxID() *LockOrderFulfillmentUpsertBulk {
 	return u.Update(func(s *LockOrderFulfillmentUpsert) {
 		s.UpdateTxID()
+	})
+}
+
+// ClearTxID clears the value of the "tx_id" field.
+func (u *LockOrderFulfillmentUpsertBulk) ClearTxID() *LockOrderFulfillmentUpsertBulk {
+	return u.Update(func(s *LockOrderFulfillmentUpsert) {
+		s.ClearTxID()
 	})
 }
 

--- a/ent/lockorderfulfillment_update.go
+++ b/ent/lockorderfulfillment_update.go
@@ -50,6 +50,12 @@ func (lofu *LockOrderFulfillmentUpdate) SetNillableTxID(s *string) *LockOrderFul
 	return lofu
 }
 
+// ClearTxID clears the value of the "tx_id" field.
+func (lofu *LockOrderFulfillmentUpdate) ClearTxID() *LockOrderFulfillmentUpdate {
+	lofu.mutation.ClearTxID()
+	return lofu
+}
+
 // SetPsp sets the "psp" field.
 func (lofu *LockOrderFulfillmentUpdate) SetPsp(s string) *LockOrderFulfillmentUpdate {
 	lofu.mutation.SetPsp(s)
@@ -193,6 +199,9 @@ func (lofu *LockOrderFulfillmentUpdate) sqlSave(ctx context.Context) (n int, err
 	if value, ok := lofu.mutation.TxID(); ok {
 		_spec.SetField(lockorderfulfillment.FieldTxID, field.TypeString, value)
 	}
+	if lofu.mutation.TxIDCleared() {
+		_spec.ClearField(lockorderfulfillment.FieldTxID, field.TypeString)
+	}
 	if value, ok := lofu.mutation.Psp(); ok {
 		_spec.SetField(lockorderfulfillment.FieldPsp, field.TypeString, value)
 	}
@@ -274,6 +283,12 @@ func (lofuo *LockOrderFulfillmentUpdateOne) SetNillableTxID(s *string) *LockOrde
 	if s != nil {
 		lofuo.SetTxID(*s)
 	}
+	return lofuo
+}
+
+// ClearTxID clears the value of the "tx_id" field.
+func (lofuo *LockOrderFulfillmentUpdateOne) ClearTxID() *LockOrderFulfillmentUpdateOne {
+	lofuo.mutation.ClearTxID()
 	return lofuo
 }
 
@@ -449,6 +464,9 @@ func (lofuo *LockOrderFulfillmentUpdateOne) sqlSave(ctx context.Context) (_node 
 	}
 	if value, ok := lofuo.mutation.TxID(); ok {
 		_spec.SetField(lockorderfulfillment.FieldTxID, field.TypeString, value)
+	}
+	if lofuo.mutation.TxIDCleared() {
+		_spec.ClearField(lockorderfulfillment.FieldTxID, field.TypeString)
 	}
 	if value, ok := lofuo.mutation.Psp(); ok {
 		_spec.SetField(lockorderfulfillment.FieldPsp, field.TypeString, value)

--- a/ent/migrate/migrations/20250221023922_token_base_currency.sql
+++ b/ent/migrate/migrations/20250221023922_token_base_currency.sql
@@ -1,0 +1,2 @@
+-- Modify "tokens" table
+ALTER TABLE "tokens" ADD COLUMN "base_currency" character varying NOT NULL DEFAULT 'USD';

--- a/ent/migrate/migrations/atlas.sum
+++ b/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:dR+GjJoPfeuDFy3ZE8clPJfTvnRV/Q1LPkeT1nxVxJ4=
+h1:iHKo49LvgKRM8ol9ndOO5B1h4uCOFE/M1eqNVUyvJFw=
 20240118234246_initial.sql h1:dYuYBqns33WT+3p8VQvbKUP62k3k6w6h8S+FqNqgSvU=
 20240130122324_order_from_address.sql h1:mMVI2iBUd1roIYLUqu0d2jZ7+B6exppRN8qqn+aIHx4=
 20240202010744_fees_on_order.sql h1:P7ngxZKqDKefBM5vk6M3kbWeMPVwbZ4MZVcLBjEfS34=
@@ -44,3 +44,4 @@ h1:dR+GjJoPfeuDFy3ZE8clPJfTvnRV/Q1LPkeT1nxVxJ4=
 20241226183354_add_reference.sql h1:oS3oVJcfD6q7EvDQrTWudCEf3HjBm/yI8XTlPvGqLC8=
 20250205002723_lof_optional_txid.sql h1:Ew1wBRx/K1cBIA//BAOjReVJW11idWCIkLnuaF8FdXY=
 20250220014823_aa_to_db.sql h1:pqbdJZe7CXgXI7ak+ggHUhjncM7l5Kiw02S4N/hqCXU=
+20250221023922_token_base_currency.sql h1:rSJE0hgZII8Fhn2QTlvCHq5XfU0+yaw5U613z9ObWT8=

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -131,7 +131,7 @@ var (
 		{Name: "id", Type: field.TypeUUID},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
-		{Name: "tx_id", Type: field.TypeString, Unique: true},
+		{Name: "tx_id", Type: field.TypeString, Nullable: true},
 		{Name: "psp", Type: field.TypeString, Nullable: true},
 		{Name: "validation_status", Type: field.TypeEnum, Enums: []string{"pending", "success", "failed"}, Default: "pending"},
 		{Name: "validation_error", Type: field.TypeString, Nullable: true},
@@ -524,6 +524,7 @@ var (
 		{Name: "contract_address", Type: field.TypeString, Size: 60},
 		{Name: "decimals", Type: field.TypeInt8},
 		{Name: "is_enabled", Type: field.TypeBool, Default: false},
+		{Name: "base_currency", Type: field.TypeString, Default: "USD"},
 		{Name: "network_tokens", Type: field.TypeInt},
 	}
 	// TokensTable holds the schema information for the "tokens" table.
@@ -534,7 +535,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "tokens_networks_tokens",
-				Columns:    []*schema.Column{TokensColumns[7]},
+				Columns:    []*schema.Column{TokensColumns[8]},
 				RefColumns: []*schema.Column{NetworksColumns[0]},
 				OnDelete:   schema.Cascade,
 			},

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -4289,9 +4289,22 @@ func (m *LockOrderFulfillmentMutation) OldTxID(ctx context.Context) (v string, e
 	return oldValue.TxID, nil
 }
 
+// ClearTxID clears the value of the "tx_id" field.
+func (m *LockOrderFulfillmentMutation) ClearTxID() {
+	m.tx_id = nil
+	m.clearedFields[lockorderfulfillment.FieldTxID] = struct{}{}
+}
+
+// TxIDCleared returns if the "tx_id" field was cleared in this mutation.
+func (m *LockOrderFulfillmentMutation) TxIDCleared() bool {
+	_, ok := m.clearedFields[lockorderfulfillment.FieldTxID]
+	return ok
+}
+
 // ResetTxID resets all changes to the "tx_id" field.
 func (m *LockOrderFulfillmentMutation) ResetTxID() {
 	m.tx_id = nil
+	delete(m.clearedFields, lockorderfulfillment.FieldTxID)
 }
 
 // SetPsp sets the "psp" field.
@@ -4642,6 +4655,9 @@ func (m *LockOrderFulfillmentMutation) AddField(name string, value ent.Value) er
 // mutation.
 func (m *LockOrderFulfillmentMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(lockorderfulfillment.FieldTxID) {
+		fields = append(fields, lockorderfulfillment.FieldTxID)
+	}
 	if m.FieldCleared(lockorderfulfillment.FieldPsp) {
 		fields = append(fields, lockorderfulfillment.FieldPsp)
 	}
@@ -4662,6 +4678,9 @@ func (m *LockOrderFulfillmentMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *LockOrderFulfillmentMutation) ClearField(name string) error {
 	switch name {
+	case lockorderfulfillment.FieldTxID:
+		m.ClearTxID()
+		return nil
 	case lockorderfulfillment.FieldPsp:
 		m.ClearPsp()
 		return nil
@@ -17098,6 +17117,7 @@ type TokenMutation struct {
 	decimals                   *int8
 	adddecimals                *int8
 	is_enabled                 *bool
+	base_currency              *string
 	clearedFields              map[string]struct{}
 	network                    *int
 	clearednetwork             bool
@@ -17449,6 +17469,42 @@ func (m *TokenMutation) ResetIsEnabled() {
 	m.is_enabled = nil
 }
 
+// SetBaseCurrency sets the "base_currency" field.
+func (m *TokenMutation) SetBaseCurrency(s string) {
+	m.base_currency = &s
+}
+
+// BaseCurrency returns the value of the "base_currency" field in the mutation.
+func (m *TokenMutation) BaseCurrency() (r string, exists bool) {
+	v := m.base_currency
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldBaseCurrency returns the old "base_currency" field's value of the Token entity.
+// If the Token object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *TokenMutation) OldBaseCurrency(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldBaseCurrency is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldBaseCurrency requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldBaseCurrency: %w", err)
+	}
+	return oldValue.BaseCurrency, nil
+}
+
+// ResetBaseCurrency resets all changes to the "base_currency" field.
+func (m *TokenMutation) ResetBaseCurrency() {
+	m.base_currency = nil
+}
+
 // SetNetworkID sets the "network" edge to the Network entity by id.
 func (m *TokenMutation) SetNetworkID(id int) {
 	m.network = &id
@@ -17684,7 +17740,7 @@ func (m *TokenMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *TokenMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.created_at != nil {
 		fields = append(fields, token.FieldCreatedAt)
 	}
@@ -17702,6 +17758,9 @@ func (m *TokenMutation) Fields() []string {
 	}
 	if m.is_enabled != nil {
 		fields = append(fields, token.FieldIsEnabled)
+	}
+	if m.base_currency != nil {
+		fields = append(fields, token.FieldBaseCurrency)
 	}
 	return fields
 }
@@ -17723,6 +17782,8 @@ func (m *TokenMutation) Field(name string) (ent.Value, bool) {
 		return m.Decimals()
 	case token.FieldIsEnabled:
 		return m.IsEnabled()
+	case token.FieldBaseCurrency:
+		return m.BaseCurrency()
 	}
 	return nil, false
 }
@@ -17744,6 +17805,8 @@ func (m *TokenMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldDecimals(ctx)
 	case token.FieldIsEnabled:
 		return m.OldIsEnabled(ctx)
+	case token.FieldBaseCurrency:
+		return m.OldBaseCurrency(ctx)
 	}
 	return nil, fmt.Errorf("unknown Token field %s", name)
 }
@@ -17794,6 +17857,13 @@ func (m *TokenMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetIsEnabled(v)
+		return nil
+	case token.FieldBaseCurrency:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetBaseCurrency(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Token field %s", name)
@@ -17876,6 +17946,9 @@ func (m *TokenMutation) ResetField(name string) error {
 		return nil
 	case token.FieldIsEnabled:
 		m.ResetIsEnabled()
+		return nil
+	case token.FieldBaseCurrency:
+		m.ResetBaseCurrency()
 		return nil
 	}
 	return fmt.Errorf("unknown Token field %s", name)

--- a/ent/runtime/runtime.go
+++ b/ent/runtime/runtime.go
@@ -402,6 +402,10 @@ func init() {
 	tokenDescIsEnabled := tokenFields[3].Descriptor()
 	// token.DefaultIsEnabled holds the default value on creation for the is_enabled field.
 	token.DefaultIsEnabled = tokenDescIsEnabled.Default.(bool)
+	// tokenDescBaseCurrency is the schema descriptor for base_currency field.
+	tokenDescBaseCurrency := tokenFields[4].Descriptor()
+	// token.DefaultBaseCurrency holds the default value on creation for the base_currency field.
+	token.DefaultBaseCurrency = tokenDescBaseCurrency.Default.(string)
 	transactionlogFields := schema.TransactionLog{}.Fields()
 	_ = transactionlogFields
 	// transactionlogDescCreatedAt is the schema descriptor for created_at field.

--- a/ent/schema/token.go
+++ b/ent/schema/token.go
@@ -26,6 +26,7 @@ func (Token) Fields() []ent.Field {
 		field.String("contract_address").MaxLen(60),
 		field.Int8("decimals"),
 		field.Bool("is_enabled").Default(false),
+		field.String("base_currency").Default("USD"),
 	}
 }
 

--- a/ent/token.go
+++ b/ent/token.go
@@ -30,6 +30,8 @@ type Token struct {
 	Decimals int8 `json:"decimals,omitempty"`
 	// IsEnabled holds the value of the "is_enabled" field.
 	IsEnabled bool `json:"is_enabled,omitempty"`
+	// BaseCurrency holds the value of the "base_currency" field.
+	BaseCurrency string `json:"base_currency,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the TokenQuery when eager-loading is set.
 	Edges          TokenEdges `json:"edges"`
@@ -99,7 +101,7 @@ func (*Token) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case token.FieldID, token.FieldDecimals:
 			values[i] = new(sql.NullInt64)
-		case token.FieldSymbol, token.FieldContractAddress:
+		case token.FieldSymbol, token.FieldContractAddress, token.FieldBaseCurrency:
 			values[i] = new(sql.NullString)
 		case token.FieldCreatedAt, token.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -161,6 +163,12 @@ func (t *Token) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field is_enabled", values[i])
 			} else if value.Valid {
 				t.IsEnabled = value.Bool
+			}
+		case token.FieldBaseCurrency:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field base_currency", values[i])
+			} else if value.Valid {
+				t.BaseCurrency = value.String
 			}
 		case token.ForeignKeys[0]:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -242,6 +250,9 @@ func (t *Token) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("is_enabled=")
 	builder.WriteString(fmt.Sprintf("%v", t.IsEnabled))
+	builder.WriteString(", ")
+	builder.WriteString("base_currency=")
+	builder.WriteString(t.BaseCurrency)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/token/token.go
+++ b/ent/token/token.go
@@ -26,6 +26,8 @@ const (
 	FieldDecimals = "decimals"
 	// FieldIsEnabled holds the string denoting the is_enabled field in the database.
 	FieldIsEnabled = "is_enabled"
+	// FieldBaseCurrency holds the string denoting the base_currency field in the database.
+	FieldBaseCurrency = "base_currency"
 	// EdgeNetwork holds the string denoting the network edge name in mutations.
 	EdgeNetwork = "network"
 	// EdgePaymentOrders holds the string denoting the payment_orders edge name in mutations.
@@ -75,6 +77,7 @@ var Columns = []string{
 	FieldContractAddress,
 	FieldDecimals,
 	FieldIsEnabled,
+	FieldBaseCurrency,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the "tokens"
@@ -111,6 +114,8 @@ var (
 	ContractAddressValidator func(string) error
 	// DefaultIsEnabled holds the default value on creation for the "is_enabled" field.
 	DefaultIsEnabled bool
+	// DefaultBaseCurrency holds the default value on creation for the "base_currency" field.
+	DefaultBaseCurrency string
 )
 
 // OrderOption defines the ordering options for the Token queries.
@@ -149,6 +154,11 @@ func ByDecimals(opts ...sql.OrderTermOption) OrderOption {
 // ByIsEnabled orders the results by the is_enabled field.
 func ByIsEnabled(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldIsEnabled, opts...).ToFunc()
+}
+
+// ByBaseCurrency orders the results by the base_currency field.
+func ByBaseCurrency(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldBaseCurrency, opts...).ToFunc()
 }
 
 // ByNetworkField orders the results by network field.

--- a/ent/token/where.go
+++ b/ent/token/where.go
@@ -85,6 +85,11 @@ func IsEnabled(v bool) predicate.Token {
 	return predicate.Token(sql.FieldEQ(FieldIsEnabled, v))
 }
 
+// BaseCurrency applies equality check predicate on the "base_currency" field. It's identical to BaseCurrencyEQ.
+func BaseCurrency(v string) predicate.Token {
+	return predicate.Token(sql.FieldEQ(FieldBaseCurrency, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Token {
 	return predicate.Token(sql.FieldEQ(FieldCreatedAt, v))
@@ -343,6 +348,71 @@ func IsEnabledEQ(v bool) predicate.Token {
 // IsEnabledNEQ applies the NEQ predicate on the "is_enabled" field.
 func IsEnabledNEQ(v bool) predicate.Token {
 	return predicate.Token(sql.FieldNEQ(FieldIsEnabled, v))
+}
+
+// BaseCurrencyEQ applies the EQ predicate on the "base_currency" field.
+func BaseCurrencyEQ(v string) predicate.Token {
+	return predicate.Token(sql.FieldEQ(FieldBaseCurrency, v))
+}
+
+// BaseCurrencyNEQ applies the NEQ predicate on the "base_currency" field.
+func BaseCurrencyNEQ(v string) predicate.Token {
+	return predicate.Token(sql.FieldNEQ(FieldBaseCurrency, v))
+}
+
+// BaseCurrencyIn applies the In predicate on the "base_currency" field.
+func BaseCurrencyIn(vs ...string) predicate.Token {
+	return predicate.Token(sql.FieldIn(FieldBaseCurrency, vs...))
+}
+
+// BaseCurrencyNotIn applies the NotIn predicate on the "base_currency" field.
+func BaseCurrencyNotIn(vs ...string) predicate.Token {
+	return predicate.Token(sql.FieldNotIn(FieldBaseCurrency, vs...))
+}
+
+// BaseCurrencyGT applies the GT predicate on the "base_currency" field.
+func BaseCurrencyGT(v string) predicate.Token {
+	return predicate.Token(sql.FieldGT(FieldBaseCurrency, v))
+}
+
+// BaseCurrencyGTE applies the GTE predicate on the "base_currency" field.
+func BaseCurrencyGTE(v string) predicate.Token {
+	return predicate.Token(sql.FieldGTE(FieldBaseCurrency, v))
+}
+
+// BaseCurrencyLT applies the LT predicate on the "base_currency" field.
+func BaseCurrencyLT(v string) predicate.Token {
+	return predicate.Token(sql.FieldLT(FieldBaseCurrency, v))
+}
+
+// BaseCurrencyLTE applies the LTE predicate on the "base_currency" field.
+func BaseCurrencyLTE(v string) predicate.Token {
+	return predicate.Token(sql.FieldLTE(FieldBaseCurrency, v))
+}
+
+// BaseCurrencyContains applies the Contains predicate on the "base_currency" field.
+func BaseCurrencyContains(v string) predicate.Token {
+	return predicate.Token(sql.FieldContains(FieldBaseCurrency, v))
+}
+
+// BaseCurrencyHasPrefix applies the HasPrefix predicate on the "base_currency" field.
+func BaseCurrencyHasPrefix(v string) predicate.Token {
+	return predicate.Token(sql.FieldHasPrefix(FieldBaseCurrency, v))
+}
+
+// BaseCurrencyHasSuffix applies the HasSuffix predicate on the "base_currency" field.
+func BaseCurrencyHasSuffix(v string) predicate.Token {
+	return predicate.Token(sql.FieldHasSuffix(FieldBaseCurrency, v))
+}
+
+// BaseCurrencyEqualFold applies the EqualFold predicate on the "base_currency" field.
+func BaseCurrencyEqualFold(v string) predicate.Token {
+	return predicate.Token(sql.FieldEqualFold(FieldBaseCurrency, v))
+}
+
+// BaseCurrencyContainsFold applies the ContainsFold predicate on the "base_currency" field.
+func BaseCurrencyContainsFold(v string) predicate.Token {
+	return predicate.Token(sql.FieldContainsFold(FieldBaseCurrency, v))
 }
 
 // HasNetwork applies the HasEdge predicate on the "network" edge.

--- a/ent/token_create.go
+++ b/ent/token_create.go
@@ -87,6 +87,20 @@ func (tc *TokenCreate) SetNillableIsEnabled(b *bool) *TokenCreate {
 	return tc
 }
 
+// SetBaseCurrency sets the "base_currency" field.
+func (tc *TokenCreate) SetBaseCurrency(s string) *TokenCreate {
+	tc.mutation.SetBaseCurrency(s)
+	return tc
+}
+
+// SetNillableBaseCurrency sets the "base_currency" field if the given value is not nil.
+func (tc *TokenCreate) SetNillableBaseCurrency(s *string) *TokenCreate {
+	if s != nil {
+		tc.SetBaseCurrency(*s)
+	}
+	return tc
+}
+
 // SetNetworkID sets the "network" edge to the Network entity by ID.
 func (tc *TokenCreate) SetNetworkID(id int) *TokenCreate {
 	tc.mutation.SetNetworkID(id)
@@ -190,6 +204,10 @@ func (tc *TokenCreate) defaults() {
 		v := token.DefaultIsEnabled
 		tc.mutation.SetIsEnabled(v)
 	}
+	if _, ok := tc.mutation.BaseCurrency(); !ok {
+		v := token.DefaultBaseCurrency
+		tc.mutation.SetBaseCurrency(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -221,6 +239,9 @@ func (tc *TokenCreate) check() error {
 	}
 	if _, ok := tc.mutation.IsEnabled(); !ok {
 		return &ValidationError{Name: "is_enabled", err: errors.New(`ent: missing required field "Token.is_enabled"`)}
+	}
+	if _, ok := tc.mutation.BaseCurrency(); !ok {
+		return &ValidationError{Name: "base_currency", err: errors.New(`ent: missing required field "Token.base_currency"`)}
 	}
 	if len(tc.mutation.NetworkIDs()) == 0 {
 		return &ValidationError{Name: "network", err: errors.New(`ent: missing required edge "Token.network"`)}
@@ -275,6 +296,10 @@ func (tc *TokenCreate) createSpec() (*Token, *sqlgraph.CreateSpec) {
 	if value, ok := tc.mutation.IsEnabled(); ok {
 		_spec.SetField(token.FieldIsEnabled, field.TypeBool, value)
 		_node.IsEnabled = value
+	}
+	if value, ok := tc.mutation.BaseCurrency(); ok {
+		_spec.SetField(token.FieldBaseCurrency, field.TypeString, value)
+		_node.BaseCurrency = value
 	}
 	if nodes := tc.mutation.NetworkIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -459,6 +484,18 @@ func (u *TokenUpsert) UpdateIsEnabled() *TokenUpsert {
 	return u
 }
 
+// SetBaseCurrency sets the "base_currency" field.
+func (u *TokenUpsert) SetBaseCurrency(v string) *TokenUpsert {
+	u.Set(token.FieldBaseCurrency, v)
+	return u
+}
+
+// UpdateBaseCurrency sets the "base_currency" field to the value that was provided on create.
+func (u *TokenUpsert) UpdateBaseCurrency() *TokenUpsert {
+	u.SetExcluded(token.FieldBaseCurrency)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -578,6 +615,20 @@ func (u *TokenUpsertOne) SetIsEnabled(v bool) *TokenUpsertOne {
 func (u *TokenUpsertOne) UpdateIsEnabled() *TokenUpsertOne {
 	return u.Update(func(s *TokenUpsert) {
 		s.UpdateIsEnabled()
+	})
+}
+
+// SetBaseCurrency sets the "base_currency" field.
+func (u *TokenUpsertOne) SetBaseCurrency(v string) *TokenUpsertOne {
+	return u.Update(func(s *TokenUpsert) {
+		s.SetBaseCurrency(v)
+	})
+}
+
+// UpdateBaseCurrency sets the "base_currency" field to the value that was provided on create.
+func (u *TokenUpsertOne) UpdateBaseCurrency() *TokenUpsertOne {
+	return u.Update(func(s *TokenUpsert) {
+		s.UpdateBaseCurrency()
 	})
 }
 
@@ -866,6 +917,20 @@ func (u *TokenUpsertBulk) SetIsEnabled(v bool) *TokenUpsertBulk {
 func (u *TokenUpsertBulk) UpdateIsEnabled() *TokenUpsertBulk {
 	return u.Update(func(s *TokenUpsert) {
 		s.UpdateIsEnabled()
+	})
+}
+
+// SetBaseCurrency sets the "base_currency" field.
+func (u *TokenUpsertBulk) SetBaseCurrency(v string) *TokenUpsertBulk {
+	return u.Update(func(s *TokenUpsert) {
+		s.SetBaseCurrency(v)
+	})
+}
+
+// UpdateBaseCurrency sets the "base_currency" field to the value that was provided on create.
+func (u *TokenUpsertBulk) UpdateBaseCurrency() *TokenUpsertBulk {
+	return u.Update(func(s *TokenUpsert) {
+		s.UpdateBaseCurrency()
 	})
 }
 

--- a/ent/token_update.go
+++ b/ent/token_update.go
@@ -102,6 +102,20 @@ func (tu *TokenUpdate) SetNillableIsEnabled(b *bool) *TokenUpdate {
 	return tu
 }
 
+// SetBaseCurrency sets the "base_currency" field.
+func (tu *TokenUpdate) SetBaseCurrency(s string) *TokenUpdate {
+	tu.mutation.SetBaseCurrency(s)
+	return tu
+}
+
+// SetNillableBaseCurrency sets the "base_currency" field if the given value is not nil.
+func (tu *TokenUpdate) SetNillableBaseCurrency(s *string) *TokenUpdate {
+	if s != nil {
+		tu.SetBaseCurrency(*s)
+	}
+	return tu
+}
+
 // SetNetworkID sets the "network" edge to the Network entity by ID.
 func (tu *TokenUpdate) SetNetworkID(id int) *TokenUpdate {
 	tu.mutation.SetNetworkID(id)
@@ -315,6 +329,9 @@ func (tu *TokenUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := tu.mutation.IsEnabled(); ok {
 		_spec.SetField(token.FieldIsEnabled, field.TypeBool, value)
+	}
+	if value, ok := tu.mutation.BaseCurrency(); ok {
+		_spec.SetField(token.FieldBaseCurrency, field.TypeString, value)
 	}
 	if tu.mutation.NetworkCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -569,6 +586,20 @@ func (tuo *TokenUpdateOne) SetNillableIsEnabled(b *bool) *TokenUpdateOne {
 	return tuo
 }
 
+// SetBaseCurrency sets the "base_currency" field.
+func (tuo *TokenUpdateOne) SetBaseCurrency(s string) *TokenUpdateOne {
+	tuo.mutation.SetBaseCurrency(s)
+	return tuo
+}
+
+// SetNillableBaseCurrency sets the "base_currency" field if the given value is not nil.
+func (tuo *TokenUpdateOne) SetNillableBaseCurrency(s *string) *TokenUpdateOne {
+	if s != nil {
+		tuo.SetBaseCurrency(*s)
+	}
+	return tuo
+}
+
 // SetNetworkID sets the "network" edge to the Network entity by ID.
 func (tuo *TokenUpdateOne) SetNetworkID(id int) *TokenUpdateOne {
 	tuo.mutation.SetNetworkID(id)
@@ -812,6 +843,9 @@ func (tuo *TokenUpdateOne) sqlSave(ctx context.Context) (_node *Token, err error
 	}
 	if value, ok := tuo.mutation.IsEnabled(); ok {
 		_spec.SetField(token.FieldIsEnabled, field.TypeBool, value)
+	}
+	if value, ok := tuo.mutation.BaseCurrency(); ok {
+		_spec.SetField(token.FieldBaseCurrency, field.TypeString, value)
 	}
 	if tuo.mutation.NetworkCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/services/indexer.go
+++ b/services/indexer.go
@@ -217,6 +217,9 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 			}
 
 			// Get rate from priority queue
+			if !strings.EqualFold(token.BaseCurrency, currency.Code) && !strings.EqualFold(token.BaseCurrency, "USD") {
+				continue
+			}
 			var rateResponse decimal.Decimal
 			if !strings.EqualFold(token.BaseCurrency, currency.Code) {
 				rateResponse, err = utils.GetTokenRateFromQueue(token.Symbol, orderAmount, currency.Code, currency.MarketRate)

--- a/services/priority_queue.go
+++ b/services/priority_queue.go
@@ -191,6 +191,10 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 				continue
 			}
 
+			if rate.IsZero() {
+				continue
+			}
+
 			// Check provider's rate against the market rate to ensure it's not too far off
 			percentDeviation := utils.AbsPercentageDeviation(bucket.Edges.Currency.MarketRate, rate)
 

--- a/services/priority_queue.go
+++ b/services/priority_queue.go
@@ -414,7 +414,15 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 			continue
 		}
 
-		if order.Amount.LessThan(minOrderAmount) || order.Amount.GreaterThan(maxOrderAmount) {
+		normalizedAmount := order.Amount
+		if strings.EqualFold(order.Token.BaseCurrency, order.ProvisionBucket.Edges.Currency.Code) && order.Token.BaseCurrency != "USD" {
+			rateResponse, err := utils.GetTokenRateFromQueue("USDT", normalizedAmount, order.ProvisionBucket.Edges.Currency.Code, order.ProvisionBucket.Edges.Currency.MarketRate)
+			if err != nil {
+				continue
+			}
+			normalizedAmount = order.Amount.Div(rateResponse)
+		}
+		if normalizedAmount.LessThan(minOrderAmount) || normalizedAmount.GreaterThan(maxOrderAmount) {
 			continue
 		}
 


### PR DESCRIPTION
### Description

This pull request includes significant changes to the token rate handling, institution validation, and LockOrderFulfillment entity. The most important changes include the addition of a new `base_currency` field to the `tokens` table, updates to the token rate calculation logic, enhancements to institution validation, and modifications to the LockOrderFulfillment entity to handle nullable `tx_id` fields.

- Introduce  field to Token schema with default USD
- Update rate calculation logic to handle tokens with different base currencies
- Modify rate scaling in indexer, priority queue, and sender services
- Enhance token rate retrieval to normalize amounts across different base currencies
- Add migration and schema updates to support the new base currency feature


### References


### Testing


### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
