### PR TITLE
Fix Handling of Amounts Below Minimum Bucket in Lock Payment Orders

### DIFF
--- a/services/indexer.go
+++ b/services/indexer.go
@@ -945,7 +945,7 @@ func (s *IndexerService) CreateLockPaymentOrder(ctx context.Context, client type
 
 	provisionBucket, isLessThanMin, err := s.getProvisionBucket(ctx, amountInDecimals.Mul(rate), currency)
 	if err != nil {
-		return fmt.Errorf("failed to fetch provision bucket: %w", err)
+		logger.Errorf("failed to fetch provision bucket: %s %s %v", amountInDecimals, currency, err)
 	}
 
 	// Create lock payment order fields
@@ -1856,17 +1856,9 @@ func (s *IndexerService) splitLockPaymentOrder(ctx context.Context, client types
 	largestBucket := buckets[0]
 
 	if amountToSplit.LessThan(largestBucket.MaxAmount) {
-		bucket, isLessThanMin, err := s.getProvisionBucket(ctx, amountToSplit, currency)
+		bucket, _, err := s.getProvisionBucket(ctx, amountToSplit, currency)
 		if err != nil {
 			return err
-		}
-
-		if isLessThanMin {
-			err := s.handleCancellation(ctx, client, nil, &lockPaymentOrder, "amount to split below minimum bucket threshold")
-			if err != nil {
-				logger.Errorf("failed to cancel split payment order: %v", err)
-			}
-			return nil // Or return an error if required
 		}
 
 		orderCreatedUpdate := db.Client.LockPaymentOrder.

--- a/services/indexer.go
+++ b/services/indexer.go
@@ -968,7 +968,7 @@ func (s *IndexerService) CreateLockPaymentOrder(ctx context.Context, client type
 	if isLessThanMin {
 		err := s.handleCancellation(ctx, client, nil, &lockPaymentOrder, "Amount is less than the minimum bucket")
 		if err != nil {
-			return nil
+			return fmt.Errorf("failed to handle cancellation: %w", err)
 		}
 		return nil
 	}
@@ -1746,6 +1746,7 @@ func (s *IndexerService) getProvisionBucket(ctx context.Context, amount decimal.
 		}
 		return nil, false, fmt.Errorf("failed to fetch provision bucket: %w", err)
 	}
+
 	return provisionBucket, false, nil
 }
 

--- a/services/indexer.go
+++ b/services/indexer.go
@@ -27,7 +27,6 @@ import (
 	"github.com/paycrest/aggregator/ent/provisionbucket"
 	"github.com/paycrest/aggregator/ent/receiveaddress"
 	"github.com/paycrest/aggregator/ent/senderprofile"
-	"github.com/paycrest/aggregator/ent/token"
 	tokenEnt "github.com/paycrest/aggregator/ent/token"
 	"github.com/paycrest/aggregator/ent/transactionlog"
 	"github.com/paycrest/aggregator/ent/user"
@@ -853,7 +852,7 @@ func (s *IndexerService) CreateLockPaymentOrder(ctx context.Context, client type
 				lockpaymentorder.GatewayIDEQ(gatewayId),
 			),
 			lockpaymentorder.HasTokenWith(
-				token.HasNetworkWith(
+				tokenEnt.HasNetworkWith(
 					networkent.IdentifierEQ(network.Identifier),
 				),
 			),
@@ -1226,7 +1225,7 @@ func (s *IndexerService) UpdateOrderStatusRefunded(ctx context.Context, network 
 		Where(
 			paymentorder.GatewayIDEQ(gatewayId),
 			paymentorder.HasTokenWith(
-				token.HasNetworkWith(
+				tokenEnt.HasNetworkWith(
 					networkent.IdentifierEQ(network.Identifier),
 				),
 			),
@@ -1293,7 +1292,7 @@ func (s *IndexerService) UpdateOrderStatusRefunded(ctx context.Context, network 
 		Where(
 			lockpaymentorder.GatewayIDEQ(gatewayId),
 			lockpaymentorder.HasTokenWith(
-				token.HasNetworkWith(
+				tokenEnt.HasNetworkWith(
 					networkent.IdentifierEQ(network.Identifier),
 				),
 			),
@@ -1318,7 +1317,7 @@ func (s *IndexerService) UpdateOrderStatusRefunded(ctx context.Context, network 
 			Where(
 				paymentorder.GatewayIDEQ(gatewayId),
 				paymentorder.HasTokenWith(
-					token.HasNetworkWith(
+					tokenEnt.HasNetworkWith(
 						networkent.IdentifierEQ(network.Identifier),
 					),
 				),
@@ -1370,7 +1369,7 @@ func (s *IndexerService) UpdateOrderStatusSettled(ctx context.Context, network *
 		Where(
 			paymentorder.GatewayIDEQ(gatewayId),
 			paymentorder.HasTokenWith(
-				token.HasNetworkWith(
+				tokenEnt.HasNetworkWith(
 					networkent.IdentifierEQ(network.Identifier),
 				),
 			),
@@ -1435,7 +1434,7 @@ func (s *IndexerService) UpdateOrderStatusSettled(ctx context.Context, network *
 		Where(
 			lockpaymentorder.IDEQ(splitOrderId),
 			lockpaymentorder.HasTokenWith(
-				token.HasNetworkWith(
+				tokenEnt.HasNetworkWith(
 					networkent.IdentifierEQ(network.Identifier),
 				),
 			),

--- a/services/indexer_test.go
+++ b/services/indexer_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/google/uuid"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/paycrest/aggregator/ent"
 	"github.com/paycrest/aggregator/ent/enttest"
@@ -280,4 +281,145 @@ func IndexERC20Transfer(ctx context.Context, client types.RPCClient, receiveAddr
 	}
 
 	return nil
+}
+
+func TestGetProvisionBucket(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up test database client
+	client := enttest.Open(t, "sqlite3", "file:ent?mode=memory&_fk=1")
+	defer client.Close()
+	db.Client = client
+
+	// Setup test data (reusing your setup function where possible)
+	err := setup()
+	assert.NoError(t, err)
+
+	// Create a test currency (USD) with a UUID and all required fields
+	usdID := uuid.New()
+	currencyUSD, err := db.Client.FiatCurrency.
+		Create().
+		SetID(usdID).
+		SetCode("USD").
+		SetShortName("Dollar").
+		SetSymbol("$").
+		SetName("US Dollar").
+		SetMarketRate(decimal.Zero).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create USD currency: %v", err)
+	}
+
+	// Create a test currency (EUR) with a UUID and all required fields
+	eurID := uuid.New()
+	currencyEUR, err := db.Client.FiatCurrency.
+		Create().
+		SetID(eurID).
+		SetCode("EUR").
+		SetShortName("Euro").
+		SetSymbol("€").
+		SetName("Euro").
+		SetMarketRate(decimal.Zero). // Required, set to zero if not used
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create EUR currency: %v", err)
+	}
+
+	// Create provision buckets for USD
+	bucket10to100, err := db.Client.ProvisionBucket.
+		Create().
+		SetMinAmount(decimal.NewFromInt(10)).
+		SetMaxAmount(decimal.NewFromInt(100)).
+		SetCurrency(currencyUSD).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create bucket 10-100: %v", err)
+	}
+
+	bucket100to1000, err := db.Client.ProvisionBucket.
+		Create().
+		SetMinAmount(decimal.NewFromInt(100)).
+		SetMaxAmount(decimal.NewFromInt(1000)).
+		SetCurrency(currencyUSD).
+		Save(ctx)
+	if err != nil {
+		t.Fatalf("failed to create bucket 100-1000: %v", err)
+	}
+
+	indexer := testCtx.indexer
+
+	tests := []struct {
+		name            string
+		amount          decimal.Decimal
+		currency        *ent.FiatCurrency
+		wantBucket      *ent.ProvisionBucket
+		wantLessThanMin bool
+		wantErr         bool
+		errMsg          string
+	}{
+		{
+			name:            "matching_bucket_found_10to100",
+			amount:          decimal.NewFromInt(50),
+			currency:        currencyUSD,
+			wantBucket:      bucket10to100,
+			wantLessThanMin: false,
+			wantErr:         false,
+		},
+		{
+			name:            "matching_bucket_found_100to1000",
+			amount:          decimal.NewFromInt(500),
+			currency:        currencyUSD,
+			wantBucket:      bucket100to1000,
+			wantLessThanMin: false,
+			wantErr:         false,
+		},
+		{
+			name:            "below_minimum_bucket",
+			amount:          decimal.NewFromInt(5),
+			currency:        currencyUSD,
+			wantBucket:      nil,
+			wantLessThanMin: true,
+			wantErr:         false,
+		},
+		{
+			name:            "above_maximum_bucket",
+			amount:          decimal.NewFromInt(2000), // Fixed: > 1000
+			currency:        currencyUSD,
+			wantBucket:      nil,
+			wantLessThanMin: false,
+			wantErr:         true,
+			errMsg:          "failed to fetch provision bucket: ent: provision_bucket not found",
+		},
+		{
+			name:            "no_buckets_for_currency",
+			amount:          decimal.NewFromInt(50),
+			currency:        currencyEUR,
+			wantBucket:      nil,
+			wantLessThanMin: false,
+			wantErr:         true,
+			errMsg:          "failed to fetch minimum bucket: ent: provision_bucket not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bucket, isLessThanMin, err := indexer.getProvisionBucket(ctx, tt.amount, tt.currency)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.Nil(t, bucket)
+				assert.Equal(t, tt.wantLessThanMin, isLessThanMin)
+				return
+			}
+
+			assert.NoError(t, err)
+			if tt.wantBucket != nil {
+				assert.Equal(t, tt.wantBucket.ID, bucket.ID)
+			} else {
+				assert.Nil(t, bucket)
+			}
+			assert.Equal(t, tt.wantLessThanMin, isLessThanMin)
+		})
+	}
 }


### PR DESCRIPTION
### Description

This PR addresses a bug in the IndexerService where lock payment orders with amounts less than the minimum provision bucket were incorrectly processed by attempting to split them, rather than being cancelled immediately. The change ensures that such orders are properly cancelled as soon as the condition is detected, improving system reliability and preventing invalid order processing.




### References
closes #431


### Testing

This PR includes unit tests to verify the fix:

* Test Cases Added in TestGetProvisionBucket:
  *  matching_bucket_found_10to100: Verifies correct bucket returned for amount within 10-100 range.
  * matching_bucket_found_100to1000: Verifies correct bucket for 100-1000 range.
  * below_minimum_bucket: Ensures isLessThanMin is true and no error for amounts < 10.
  * above_maximum_bucket: Confirms error returned for amounts > 1000 with no bucket.
  * no_buckets_for_currency: Validates error handling when no buckets exist for a currency.


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
