### PR TITLE
fix: prevent unnecessary Redis operations when previous values are empty (RPUSH)

### DIFF
--- a/services/priority_queue.go
+++ b/services/priority_queue.go
@@ -157,9 +157,11 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 	}
 
 	// Update the previous queue
-	err = storage.RedisClient.RPush(ctx, prevRedisKey, prevValues...).Err()
-	if err != nil && err != context.Canceled {
-		logger.Errorf("failed to store previous provider rates: %v", err)
+	if len(prevValues) > 0 {
+		err = storage.RedisClient.RPush(ctx, prevRedisKey, prevValues...).Err()
+		if err != nil && err != context.Canceled {
+			logger.Errorf("failed to store previous provider rates: %v", err)
+		}
 	}
 
 	// Delete the current queue


### PR DESCRIPTION
### Description
The Error `error failed to store previous provider rates: ERR wrong number of arguments` for 'rpush' command occurs in the Priority Queue Service when attempting to store previous provider rates in Redis. This error indicates that the rpush command is being called with an incorrect number of arguments.

The issue occurs because we're trying to call RPUSH even when there are no previous values to store.

This fix:

- [x] Checks if there are any previous values to store before calling RPUSH
- [x] Only executes the RPUSH command if there are actual values to store
- [x] Prevents the "ERR wrong number of arguments" Redis error



### References

 closes #439 


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
