### PR TITLE
fix: renamed currency type json for multiple currencies support

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -118,7 +118,7 @@ type RegisterPayload struct {
 	LastName     string     `json:"lastName" binding:"required"`
 	Email        string     `json:"email" binding:"required,email"`
 	Password     string     `json:"password" binding:"required,min=6,max=20"`
-	Currencies  []string    `json:"currency"`
+	Currencies  []string    `json:"currencies"`
 	Scopes      []string    `json:"scopes" binding:"required,dive,oneof=sender provider"`
 }
 


### PR DESCRIPTION
### Description

> Minor update of endpoint json field from `currency` to `currencies`

### Testing

> Trying to register the user by using this payload
`{
  firstName: 'Jeremiah',
  lastName: 'Black,
  email: 'email@yopmail.com',
  password: 'password',
  currencies: [ 'NGN' ],
  scopes: [ 'sender', 'provider' ]
}`

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
