### PR TITLE
fix: supporting email returning during sign up for local & staging envs

### DIFF
--- a/controllers/accounts/auth.go
+++ b/controllers/accounts/auth.go
@@ -233,7 +233,8 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 		LastName:  user.LastName,
 	}
 
-	if !user.IsEmailVerified {
+	// Set email if either condition is true
+	if serverConf.Environment != "production" || !user.IsEmailVerified {
 		response.Email = user.Email
 	}
 

--- a/controllers/accounts/auth_test.go
+++ b/controllers/accounts/auth_test.go
@@ -139,7 +139,6 @@ func TestAuth(t *testing.T) {
 			// Parse the user ID string to uuid.UUID
 			userUUID, err := uuid.Parse(userID)
 			assert.NoError(t, err)
-			assert.Equal(t, "", data["email"].(string))
 			assert.Equal(t, payload.FirstName, data["firstName"].(string))
 			assert.Equal(t, payload.LastName, data["lastName"].(string))
 
@@ -202,7 +201,6 @@ func TestAuth(t *testing.T) {
 			// Parse the user ID string to uuid.UUID
 			userUUID, err := uuid.Parse(userID)
 			assert.NoError(t, err)
-			assert.Equal(t, "", data["email"].(string))
 			assert.Equal(t, payload.FirstName, data["firstName"].(string))
 			assert.Equal(t, payload.LastName, data["lastName"].(string))
 
@@ -263,7 +261,6 @@ func TestAuth(t *testing.T) {
 			// Parse the user ID string to uuid.UUID
 			userUUID, err := uuid.Parse(data["id"].(string))
 			assert.NoError(t, err)
-			assert.Equal(t, "", data["email"].(string))
 			assert.Equal(t, payload.FirstName, data["firstName"].(string))
 			assert.Equal(t, payload.LastName, data["lastName"].(string))
 


### PR DESCRIPTION


### Description

> Supporting email returning during sign up for local & staging envs

### Testing

> Try registering as either a provider or sender or both on staging or local, the response payload should have the `email` field. 


### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
