### PR TITLE
Add `/v1/tokens` Endpoint to Fetch Supported Tokens

### DIFF
--- a/controllers/index.go
+++ b/controllers/index.go
@@ -259,6 +259,47 @@ func (ctrl *Controller) GetTokenRate(ctx *gin.Context) {
 	u.APIResponse(ctx, http.StatusOK, "success", "Rate fetched successfully", rateResponse)
 }
 
+// GetSupportedTokens controller fetches supported cryptocurrency tokens
+func (ctrl *Controller) GetSupportedTokens(ctx *gin.Context) {
+	// Get network filter from query parameter
+	networkFilter := ctx.Query("network")
+
+	// Build query
+	query := storage.Client.Token.
+		Query().
+		Where(token.IsEnabled(true)).
+		WithNetwork()
+
+	// Apply network filter if provided
+	if networkFilter != "" {
+		query = query.Where(token.HasNetworkWith(
+			network.Identifier(strings.ToLower(networkFilter)),
+		))
+	}
+
+	// Execute query
+	tokens, err := query.All(ctx)
+	if err != nil {
+		logger.Errorf("error: %v", err)
+		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to fetch tokens", nil)
+		return
+	}
+
+	// Transform tokens for response
+	response := make([]types.SupportedTokenResponse, 0, len(tokens))
+	for _, t := range tokens {
+		response = append(response, types.SupportedTokenResponse{
+			Symbol:          t.Symbol,
+			ContractAddress: t.ContractAddress,
+			Decimals:        t.Decimals,
+			BaseCurrency:    t.BaseCurrency,
+			Network:         t.Edges.Network.Identifier,
+		})
+	}
+
+	u.APIResponse(ctx, http.StatusOK, "success", "Tokens retrieved successfully", response)
+}
+
 // GetAggregatorPublicKey controller expose Aggregator Public Key
 func (ctrl *Controller) GetAggregatorPublicKey(ctx *gin.Context) {
 	u.APIResponse(ctx, http.StatusOK, "success", "OK", cryptoConf.AggregatorPublicKey)

--- a/controllers/index_test.go
+++ b/controllers/index_test.go
@@ -266,7 +266,7 @@ func TestIndex(t *testing.T) {
 
 	t.Run("GetSupportedTokens", func(t *testing.T) {
 		// Setup test data for tokens
-		networks, tokens := test.CrateTestTokenData(t, client)
+		networks, tokens := test.CreateTestTokenData(t, client)
 
 		// Define response structure
 		type Response struct {

--- a/controllers/index_test.go
+++ b/controllers/index_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/paycrest/aggregator/ent/enttest"
 	"github.com/paycrest/aggregator/ent/identityverificationrequest"
+	"github.com/paycrest/aggregator/ent/token"
 	"github.com/paycrest/aggregator/utils/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,6 +59,7 @@ func TestIndex(t *testing.T) {
 	router.POST("kyc", ctrl.RequestIDVerification)
 	router.GET("kyc/:wallet_address", ctrl.GetIDVerificationStatus)
 	router.POST("kyc/webhook", ctrl.KYCWebhook)
+	router.GET("/v1/tokens", ctrl.GetSupportedTokens)
 
 	t.Run("GetInstitutions By Currency", func(t *testing.T) {
 
@@ -260,5 +262,90 @@ func TestIndex(t *testing.T) {
 		data, ok := response.Data.(map[string]interface{})
 		assert.True(t, ok, "response.Data is not of type map[string]interface{}")
 		assert.Equal(t, "pending", data["status"])
+	})
+
+	t.Run("GetSupportedTokens", func(t *testing.T) {
+		// Setup test data for tokens
+		networks, tokens := test.CrateTestTokenData(t, client)
+
+		// Define response structure
+		type Response struct {
+			Status  string                         `json:"status"`
+			Message string                         `json:"message"`
+			Data    []types.SupportedTokenResponse `json:"data"`
+		}
+
+		t.Run("Fetch all enabled tokens", func(t *testing.T) {
+			res, err := test.PerformRequest(t, "GET", "/v1/tokens", nil, nil, router)
+			assert.NoError(t, err)
+
+			assert.Equal(t, http.StatusOK, res.Code)
+
+			var response Response
+			err = json.Unmarshal(res.Body.Bytes(), &response)
+			assert.NoError(t, err)
+			assert.Equal(t, "success", response.Status)
+			assert.Equal(t, "Tokens retrieved successfully", response.Message)
+			assert.Equal(t, 2, len(response.Data)) // Should only include enabled tokens
+
+			// Verify token details
+			assert.Equal(t, tokens[0].Symbol, response.Data[0].Symbol)
+			assert.Equal(t, tokens[0].ContractAddress, response.Data[0].ContractAddress)
+			assert.Equal(t, tokens[0].Decimals, response.Data[0].Decimals)
+			assert.Equal(t, tokens[0].BaseCurrency, response.Data[0].BaseCurrency)
+			assert.Equal(t, networks[0].Identifier, response.Data[0].Network)
+		})
+
+		t.Run("Fetch tokens by network", func(t *testing.T) {
+			res, err := test.PerformRequest(t, "GET", "/v1/tokens?network=arbitrum-one", nil, nil, router)
+			assert.NoError(t, err)
+
+			assert.Equal(t, http.StatusOK, res.Code)
+
+			var response Response
+			err = json.Unmarshal(res.Body.Bytes(), &response)
+			assert.NoError(t, err)
+			assert.Equal(t, "success", response.Status)
+			assert.Equal(t, "Tokens retrieved successfully", response.Message)
+			assert.Equal(t, 1, len(response.Data)) // Should only include tokens for the specified network
+
+			assert.Equal(t, "USDC", response.Data[0].Symbol)
+			assert.Equal(t, "arbitrum-one", response.Data[0].Network)
+		})
+
+		t.Run("Fetch with invalid network", func(t *testing.T) {
+			res, err := test.PerformRequest(t, "GET", "/v1/tokens?network=invalid-network", nil, nil, router)
+			assert.NoError(t, err)
+
+			assert.Equal(t, http.StatusOK, res.Code)
+
+			var response Response
+			err = json.Unmarshal(res.Body.Bytes(), &response)
+			assert.NoError(t, err)
+			assert.Equal(t, "success", response.Status)
+			assert.Equal(t, "Tokens retrieved successfully", response.Message)
+			assert.Equal(t, 0, len(response.Data)) // No tokens for invalid network
+		})
+
+		t.Run("Fetch with no enabled tokens", func(t *testing.T) {
+			// Disable all tokens
+			_, err := client.Token.Update().
+				Where(token.IsEnabled(true)).
+				SetIsEnabled(false).
+				Save(context.Background())
+			assert.NoError(t, err)
+
+			res, err := test.PerformRequest(t, "GET", "/v1/tokens", nil, nil, router)
+			assert.NoError(t, err)
+
+			assert.Equal(t, http.StatusOK, res.Code)
+
+			var response Response
+			err = json.Unmarshal(res.Body.Bytes(), &response)
+			assert.NoError(t, err)
+			assert.Equal(t, "success", response.Status)
+			assert.Equal(t, "Tokens retrieved successfully", response.Message)
+			assert.Equal(t, 0, len(response.Data)) // No enabled tokens
+		})
 	})
 }

--- a/routers/index.go
+++ b/routers/index.go
@@ -37,6 +37,7 @@ func RegisterRoutes(route *gin.Engine) {
 		"institutions/:currency_code",
 		ctrl.GetInstitutionsByCurrency,
 	)
+	v1.GET("tokens", ctrl.GetSupportedTokens)
 	v1.GET("rates/:token/:amount/:fiat", ctrl.GetTokenRate)
 	v1.GET("pubkey", ctrl.GetAggregatorPublicKey)
 	v1.POST("verify-account", ctrl.VerifyAccount)

--- a/types/types.go
+++ b/types/types.go
@@ -674,3 +674,12 @@ type LinkedAddressTransactionList struct {
 	PageSize     int                        `json:"pageSize"`
 	Transactions []LinkedAddressTransaction `json:"transactions"`
 }
+
+// SupportedTokenResponse represents the structure for supported tokens
+type SupportedTokenResponse struct {
+	Symbol          string `json:"symbol"`
+	ContractAddress string `json:"contractAddress"`
+	Decimals        int8   `json:"decimals"`
+	BaseCurrency    string `json:"baseCurrency"`
+	Network         string `json:"network"`
+}

--- a/utils/test/db.go
+++ b/utils/test/db.go
@@ -644,7 +644,7 @@ func CreateTestFiatCurrency(overrides map[string]interface{}) (*ent.FiatCurrency
 }
 
 // Helper function to create test networks and tokens
-func CrateTestTokenData(t *testing.T, client *ent.Client) ([]*ent.Network, []*ent.Token) {
+func CreateTestTokenData(t *testing.T, client *ent.Client) ([]*ent.Network, []*ent.Token) {
 	ctx := context.Background()
 
 	// Create test networks

--- a/utils/test/db.go
+++ b/utils/test/db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -25,6 +26,7 @@ import (
 	db "github.com/paycrest/aggregator/storage"
 	"github.com/paycrest/aggregator/types"
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
 )
 
 // CreateTestUser creates a test user with default or custom values
@@ -639,6 +641,66 @@ func CreateTestFiatCurrency(overrides map[string]interface{}) (*ent.FiatCurrency
 		Save(context.Background())
 	return currency, err
 
+}
+
+// Helper function to create test networks and tokens
+func CrateTestTokenData(t *testing.T, client *ent.Client) ([]*ent.Network, []*ent.Token) {
+	ctx := context.Background()
+
+	// Create test networks
+	network1, err := client.Network.Create().
+		SetIdentifier("arbitrum-one").
+		SetChainID(42161).
+		SetRPCEndpoint("https://arb1.arbitrum.io/rpc").
+		SetGatewayContractAddress("0x123").
+		SetIsTestnet(false).
+		SetFee(decimal.NewFromFloat(0.01)).
+		Save(ctx)
+	assert.NoError(t, err)
+
+	network2, err := client.Network.Create().
+		SetIdentifier("polygon").
+		SetChainID(137).
+		SetRPCEndpoint("https://polygon-rpc.com").
+		SetGatewayContractAddress("0x456").
+		SetIsTestnet(false).
+		SetFee(decimal.NewFromFloat(0.02)).
+		Save(ctx)
+	assert.NoError(t, err)
+
+	// Create test tokens
+	token1, err := client.Token.Create().
+		SetSymbol("USDC").
+		SetContractAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").
+		SetDecimals(6).
+		SetBaseCurrency("USD").
+		SetIsEnabled(true).
+		SetNetwork(network1).
+		Save(ctx)
+	assert.NoError(t, err)
+
+	token2, err := client.Token.Create().
+		SetSymbol("USDT").
+		SetContractAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7").
+		SetDecimals(6).
+		SetBaseCurrency("USD").
+		SetIsEnabled(true).
+		SetNetwork(network2).
+		Save(ctx)
+	assert.NoError(t, err)
+
+	// Disabled token (should not appear in results)
+	_, err = client.Token.Create().
+		SetSymbol("DAI").
+		SetContractAddress("0x6B175474E89094C44Da98b954EedeAC495271d0F").
+		SetDecimals(18).
+		SetBaseCurrency("USD").
+		SetIsEnabled(false).
+		SetNetwork(network1).
+		Save(ctx)
+	assert.NoError(t, err)
+
+	return []*ent.Network{network1, network2}, []*ent.Token{token1, token2}
 }
 
 // CreateEnvFile creates a new file with Key=Value format.


### PR DESCRIPTION
### Description

This PR introduces a new API endpoint, `/v1/tokens`, to the aggregator service, enabling users to fetch a list of supported cryptocurrency tokens. The endpoint returns enabled tokens with details including symbol, contract address, decimals, base currency, and network identifier. It also supports optional filtering by network via a query parameter (?network=<network>).

### The implementation includes

  - A new controller function `GetSupportedTokens` in `controllers/index.go` that queries the `Token` entity, filters for `is_enabled=true`, and optionally filters by network.
  - A response struct `SupportedTokenResponse` in `types/types.go` (assumed existing or to be added) matching the required JSON format.
  - Route registration in `routers/routers.go` under the `/v1/` group.
  - Comprehensive unit tests in `controllers/index_test.go` covering all acceptance criteria.


### Changes to API
  - New endpoint: `GET /v1/tokens`
  - Optional query parameter: `network` (e.g., `/v1/tokens?network=arbitrum-one`)
  - **Response format**:
  ```json
  [
    {
      "symbol": "USDC",
      "contractAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
      "decimals": 6,
      "baseCurrency": "USD",
      "network": "arbitrum-one"
    }
  ]
```

### References

Closes #437


### Testing
              
  -  Fetching all enabled tokens (`GET /v1/tokens`).
  - Fetching tokens filtered by network (`GET /v1/tokens?network=arbitrum-one`).
  - Handling invalid network filters (`GET /v1/tokens?network=invalid-network`).
  - Handling no enabled tokens scenario.


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
