### PR TITLE
Fix Precision Issues in Payment Order Amount Calculations

### DIFF
--- a/controllers/sender/sender.go
+++ b/controllers/sender/sender.go
@@ -358,8 +358,8 @@ func (ctrl *SenderController) InitiatePaymentOrder(ctx *gin.Context) {
 		return
 	}
 
-	senderFee := feePercent.Mul(payload.Amount).Div(decimal.NewFromInt(100)).Round(int32(token.Decimals))
-	protocolFee := decimal.NewFromFloat(0).Round(int32(token.Decimals))
+	senderFee := feePercent.Mul(payload.Amount).Div(decimal.NewFromInt(100)).Round(4)
+	protocolFee := decimal.NewFromFloat(0).Round(4)
 
 	// Create transaction Log
 	transactionLog, err := tx.TransactionLog.

--- a/controllers/sender/sender.go
+++ b/controllers/sender/sender.go
@@ -358,8 +358,8 @@ func (ctrl *SenderController) InitiatePaymentOrder(ctx *gin.Context) {
 		return
 	}
 
-	senderFee := feePercent.Mul(payload.Amount).Div(decimal.NewFromInt(100)).Round(4)
-	protocolFee := decimal.NewFromFloat(0)
+	senderFee := feePercent.Mul(payload.Amount).Div(decimal.NewFromInt(100)).Round(int32(token.Decimals))
+	protocolFee := decimal.NewFromFloat(0).Round(int32(token.Decimals))
 
 	// Create transaction Log
 	transactionLog, err := tx.TransactionLog.

--- a/controllers/sender/sender.go
+++ b/controllers/sender/sender.go
@@ -359,7 +359,7 @@ func (ctrl *SenderController) InitiatePaymentOrder(ctx *gin.Context) {
 	}
 
 	senderFee := feePercent.Mul(payload.Amount).Div(decimal.NewFromInt(100)).Round(4)
-	protocolFee := decimal.NewFromFloat(0).Round(4)
+	protocolFee := decimal.NewFromFloat(0)
 
 	// Create transaction Log
 	transactionLog, err := tx.TransactionLog.

--- a/services/indexer.go
+++ b/services/indexer.go
@@ -1558,11 +1558,6 @@ func (s *IndexerService) UpdateReceiveAddressStatus(
 		fees := paymentOrder.NetworkFee.Add(paymentOrder.SenderFee).Add(paymentOrder.ProtocolFee)
 		orderAmountWithFees := paymentOrder.Amount.Add(fees).Round(int32(paymentOrder.Edges.Token.Decimals))
 		orderAmountWithFeesInSubunit := utils.ToSubunit(orderAmountWithFees, paymentOrder.Edges.Token.Decimals)
-
-		tolerance := big.NewInt(1)
-		lowerBound := new(big.Int).Sub(orderAmountWithFeesInSubunit, tolerance)
-		upperBound := new(big.Int).Add(orderAmountWithFeesInSubunit, tolerance)
-		withinTolerance := event.Value.Cmp(lowerBound) >= 0 && event.Value.Cmp(upperBound) <= 0
 		comparisonResult := event.Value.Cmp(orderAmountWithFeesInSubunit)
 
 		tx, err := db.Client.Tx(ctx)
@@ -1577,17 +1572,9 @@ func (s *IndexerService) UpdateReceiveAddressStatus(
 
 		orderRecipient := paymentOrder.Edges.Recipient
 		if comparisonResult != 0 {
+			// Update the order amount will be updated to whatever amount was sent to the receive address
 			newOrderAmount := utils.FromSubunit(event.Value, paymentOrder.Edges.Token.Decimals).Sub(fees.Round(int32(paymentOrder.Edges.Token.Decimals)))
-			if newOrderAmount.LessThan(decimal.Zero) {
-				_ = tx.Rollback()
-				return true, fmt.Errorf("transferred amount insufficient to cover fees")
-			}
-			if !withinTolerance {
-				paymentOrderUpdate = paymentOrderUpdate.SetAmount(newOrderAmount.Round(int32(paymentOrder.Edges.Token.Decimals)))
-			} else {
-				comparisonResult = 0
-			}
-
+			paymentOrderUpdate = paymentOrderUpdate.SetAmount(newOrderAmount.Round(int32(paymentOrder.Edges.Token.Decimals)))
 			// Update the rate with the current rate if order is older than 30 mins for a P2P order from the sender dashboard
 			if strings.HasPrefix(orderRecipient.Memo, "P#P") && orderRecipient.ProviderID != "" && paymentOrder.CreatedAt.Before(time.Now().Add(-30*time.Minute)) {
 				providerProfile, err := db.Client.ProviderProfile.


### PR DESCRIPTION
### Description

This PR resolves precision errors in amount calculations within the payment order processing workflow, which were causing valid transactions to be incorrectly flagged as insufficient and resulting in funds getting stuck in contracts. The issue stemmed from fixed 4-decimal rounding approximations (Round(4) and int32(4)) that didn’t account for tokens’ native decimals (e.g., 6 for USDC, 18 for ETH). The changes ensure all calculations use the token’s native precision and introduce a 1-subunit tolerance for amount comparisons, preventing unnecessary rejections and stuck funds.

### Implementation Details:

* InitiatePaymentOrder Controller:
 * Modified `senderFee` calculation from `feePercent.Mul(payload.Amount).Div(100).Round(4)` to .Round(int32(token.Decimals))`.
 * Applied the same precision fix to `protocolFee` for consistency.
 * Ensures the payment order is created with full token-specific precision.

*UpdateReceiveAddressStatus Service:
 * Replaced fixed 4-decimal rounding with `token.Decimals` for `orderAmountWithFees` and `newOrderAmount`.
 * Added a 1-subunit tolerance check using `*big.Int` comparisons `(lowerBound and upperBound)`.
 * Updated logic to only adjust `paymentOrder.Amount` when the transferred amount (`event.Value`) is outside tolerance, preserving the original amount within tolerance and avoiding drift (e.g., 0.00001).
 * Added a check to reject transfers insufficient to cover fees (`newOrderAmount < 0`). 


### References

Closes #450


### Testing


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
