### PR TITLE
Enhance logging with contextual information across services

### DIFF
--- a/controllers/accounts/auth.go
+++ b/controllers/accounts/auth.go
@@ -120,7 +120,7 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 		if verificationToken != nil {
 			if _, err := ctrl.emailService.SendVerificationEmail(ctx, verificationToken.Token, user.Email, user.FirstName); err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"Email": user.Email,
 				}).Errorf("Failed to send verification email")
 			}
@@ -184,7 +184,7 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 		if err != nil {
 			_ = tx.Rollback()
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"UserID": user.ID,
 				"Email": user.Email,
 			}).Errorf("Failed to create provider profile")
@@ -198,7 +198,7 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 		if err != nil {
 			_ = tx.Rollback()
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"UserID": user.ID,
 				"ProviderID": provider.ID,
 				"Email": user.Email,
@@ -218,7 +218,7 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 		if err != nil {
 			_ = tx.Rollback()
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"UserID": user.ID,
 				"Email": user.Email,
 			}).Errorf("Failed to create sender profile")
@@ -232,7 +232,7 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 		if err != nil {
 			_ = tx.Rollback()
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"UserID": user.ID,
 				"SenderID": sender.ID,
 				"Email": user.Email,

--- a/controllers/accounts/auth.go
+++ b/controllers/accounts/auth.go
@@ -121,7 +121,7 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 			if _, err := ctrl.emailService.SendVerificationEmail(ctx, verificationToken.Token, user.Email, user.FirstName); err != nil {
 				logger.WithFields(logger.Fields{
 					"Error": fmt.Sprintf("%v", err),
-					"Email": user.Email,
+					"UserID": user.ID,
 				}).Errorf("Failed to send verification email")
 			}
 		}
@@ -186,7 +186,6 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
 				"UserID": user.ID,
-				"Email": user.Email,
 			}).Errorf("Failed to create provider profile")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error",
 				"Failed to create new user", nil)
@@ -201,7 +200,6 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 				"Error": fmt.Sprintf("%v", err),
 				"UserID": user.ID,
 				"ProviderID": provider.ID,
-				"Email": user.Email,
 			}).Errorf("Failed to create API key for provider")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error",
 				"Failed to create new user", nil)
@@ -220,7 +218,6 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
 				"UserID": user.ID,
-				"Email": user.Email,
 			}).Errorf("Failed to create sender profile")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error",
 				"Failed to create new user", nil)
@@ -235,7 +232,6 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 				"Error": fmt.Sprintf("%v", err),
 				"UserID": user.ID,
 				"SenderID": sender.ID,
-				"Email": user.Email,
 			}).Errorf("Failed to create API key for sender")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error",
 				"Failed to create new user", nil)

--- a/controllers/accounts/auth.go
+++ b/controllers/accounts/auth.go
@@ -58,7 +58,7 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 
 	tx, err := db.Client.Tx(ctx)
 	if err != nil {
-		logger.Errorf("error: %v", err)
+		logger.Errorf("Error: Failed to create new user: %v", err)
 		u.APIResponse(ctx, http.StatusInternalServerError, "error",
 			"Failed to create new user", nil)
 		return
@@ -99,7 +99,7 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 	user, err := userCreate.Save(ctx)
 	if err != nil {
 		_ = tx.Rollback()
-		logger.Errorf("error: %v", err)
+		logger.Errorf("Error: Failed to save new user: %v", err)
 		u.APIResponse(ctx, http.StatusInternalServerError, "error",
 			"Failed to create new user", nil)
 		return
@@ -113,13 +113,16 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 		SetExpiryAt(time.Now().Add(authConf.PasswordResetLifespan)).
 		Save(ctx)
 	if err != nil {
-		logger.Errorf("error: %v", err)
+		logger.Errorf("Error: Failed to create verification token: %v", err)
 	}
 
 	if serverConf.Environment == "production" {
 		if verificationToken != nil {
 			if _, err := ctrl.emailService.SendVerificationEmail(ctx, verificationToken.Token, user.Email, user.FirstName); err != nil {
-				logger.Errorf("error: %v", err)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"Email": user.Email,
+				}).Errorf("Failed to send verification email")
 			}
 		}
 	}
@@ -180,7 +183,11 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 			Save(ctx)
 		if err != nil {
 			_ = tx.Rollback()
-			logger.Errorf("error: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"UserID": user.ID,
+				"Email": user.Email,
+			}).Errorf("Failed to create provider profile")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error",
 				"Failed to create new user", nil)
 			return
@@ -190,7 +197,12 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 		_, _, err = ctrl.apiKeyService.GenerateAPIKey(ctx, tx, nil, provider)
 		if err != nil {
 			_ = tx.Rollback()
-			logger.Errorf("error: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"UserID": user.ID,
+				"ProviderID": provider.ID,
+				"Email": user.Email,
+			}).Errorf("Failed to create API key for provider")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error",
 				"Failed to create new user", nil)
 			return
@@ -205,7 +217,11 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 			Save(ctx)
 		if err != nil {
 			_ = tx.Rollback()
-			logger.Errorf("error: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"UserID": user.ID,
+				"Email": user.Email,
+			}).Errorf("Failed to create sender profile")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error",
 				"Failed to create new user", nil)
 			return
@@ -215,7 +231,12 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 		_, _, err = ctrl.apiKeyService.GenerateAPIKey(ctx, tx, sender, nil)
 		if err != nil {
 			_ = tx.Rollback()
-			logger.Errorf("error: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"UserID": user.ID,
+				"SenderID": sender.ID,
+				"Email": user.Email,
+			}).Errorf("Failed to create API key for sender")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error",
 				"Failed to create new user", nil)
 			return
@@ -223,7 +244,7 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 	}
 
 	if err := tx.Commit(); err != nil {
-		logger.Errorf("error: %v", err)
+		logger.Errorf("Error: Failed to commit transaction: %v", err)
 		u.APIResponse(ctx, http.StatusInternalServerError, "error",
 			"Failed to create new user", nil)
 		return
@@ -246,7 +267,7 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 	// Send Slack notification
 	if serverConf.Environment == "production" {
 		if err := ctrl.slackService.SendUserSignupNotification(user, scopes, providerCurrencies); err != nil {
-			logger.Errorf("failed to send Slack notification: %v", err)
+			logger.Errorf("Failed to send Slack notification: %v", err)
 		}
 	}
 }
@@ -296,7 +317,7 @@ func (ctrl *AuthController) Login(ctx *gin.Context) {
 	accessToken, refreshToken, err := token.GeneratePairJWT(user.ID.String(), user.Scope)
 
 	if err != nil {
-		logger.Errorf("error: %v", err)
+		logger.Errorf("Error : Failed to create token pair during login: %v", err)
 		u.APIResponse(ctx, http.StatusInternalServerError, "error",
 			"Failed to create token pair", nil,
 		)

--- a/controllers/accounts/profile.go
+++ b/controllers/accounts/profile.go
@@ -281,7 +281,7 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 			All(ctx)
 		if err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"ProviderID": provider.ID,
 			}).Errorf("Failed to fetch existing currencies for provider")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to fetch existing currencies", nil)
@@ -361,7 +361,7 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 				u.APIResponse(ctx, http.StatusBadRequest, "error", fmt.Sprintf("Token not supported - %s", tokenPayload.Symbol), nil)
 			} else {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"Token": tokenPayload.Symbol,
 				}).Errorf("Failed to check token support during update")
 				u.APIResponse(
@@ -386,7 +386,7 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 				u.APIResponse(ctx, http.StatusBadRequest, "error", "Currency not supported", nil)
 			} else {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"Currency": tokenPayload.Currency,
 				}).Errorf("Failed to fetch currency during update")
 				u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to update profile", nil)
@@ -470,7 +470,7 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 				if err != nil {
 					tx.Rollback()
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"Token": tokenPayload.Symbol,
 						"Currency": tokenPayload.Currency,
 					}).Errorf("Failed to create token during update")
@@ -480,7 +480,7 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 			} else {
 				tx.Rollback()
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"Token": tokenPayload.Symbol,
 					"Currency": tokenPayload.Currency,
 				}).Errorf("Failed to query token during update")
@@ -514,7 +514,7 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 			if err != nil {
 				tx.Rollback()
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"Token": tokenPayload.Symbol,
 					"Currency": tokenPayload.Currency,
 				}).Errorf("Failed to update token during update")
@@ -543,7 +543,7 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 			All(ctx)
 		if err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"ProviderID": provider.ID,
 				"MinAmount": tokenPayload.MinOrderAmount,
 				"MaxAmount": tokenPayload.MaxOrderAmount,
@@ -562,7 +562,7 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 	_, err := update.Save(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"ProviderID": provider.ID,
 		}).Errorf("Failed to commit update of provider profile")
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to update profile", nil)
@@ -593,7 +593,7 @@ func (ctrl *ProfileController) GetSenderProfile(ctx *gin.Context) {
 	apiKey, err := ctrl.apiKeyService.GetAPIKey(ctx, sender, nil)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"SenderID": sender.ID,
 		}).Errorf("Failed to fetch sender API key")
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
@@ -611,7 +611,7 @@ func (ctrl *ProfileController) GetSenderProfile(ctx *gin.Context) {
 		All(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"SenderID": sender.ID,
 		}).Errorf("Failed to fetch sender order tokens")
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
@@ -653,7 +653,7 @@ func (ctrl *ProfileController) GetSenderProfile(ctx *gin.Context) {
 			// do nothing
 		} else {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"SenderID": sender.ID,
 			}).Errorf("Failed to fetch linked providerf for sender")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
@@ -695,7 +695,7 @@ func (ctrl *ProfileController) GetProviderProfile(ctx *gin.Context) {
 	currencies, err := provider.QueryCurrencies().All(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"ProviderID": provider.ID,
 		}).Errorf("Failed to fetch currencies for provider")
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
@@ -717,7 +717,7 @@ func (ctrl *ProfileController) GetProviderProfile(ctx *gin.Context) {
 	orderTokens, err := query.All(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"ProviderID": provider.ID,
 		}).Errorf("Failed to fetch order tokens for provider")
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
@@ -745,7 +745,7 @@ func (ctrl *ProfileController) GetProviderProfile(ctx *gin.Context) {
 	apiKey, err := ctrl.apiKeyService.GetAPIKey(ctx, nil, provider)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"ProviderID": provider.ID,
 		}).Errorf("Failed to fetch provider API key")
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)

--- a/controllers/accounts/profile.go
+++ b/controllers/accounts/profile.go
@@ -280,7 +280,10 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 			QueryCurrencies().
 			All(ctx)
 		if err != nil {
-			logger.Errorf("Failed to fetch existing currencies: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"ProviderID": provider.ID,
+			}).Errorf("Failed to fetch existing currencies for provider")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to fetch existing currencies", nil)
 			return
 		}
@@ -357,7 +360,10 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 			if ent.IsNotFound(err) {
 				u.APIResponse(ctx, http.StatusBadRequest, "error", fmt.Sprintf("Token not supported - %s", tokenPayload.Symbol), nil)
 			} else {
-				logger.Errorf("Failed to check token support: %v", err)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"Token": tokenPayload.Symbol,
+				}).Errorf("Failed to check token support during update")
 				u.APIResponse(
 					ctx,
 					http.StatusInternalServerError,
@@ -379,7 +385,10 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 			if ent.IsNotFound(err) {
 				u.APIResponse(ctx, http.StatusBadRequest, "error", "Currency not supported", nil)
 			} else {
-				logger.Errorf("Failed to fetch currency: %v", err)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"Currency": tokenPayload.Currency,
+				}).Errorf("Failed to fetch currency during update")
 				u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to update profile", nil)
 			}
 			return
@@ -398,7 +407,12 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 		// Get rate for provider
 		rate, err := ctrl.priorityQueueService.GetProviderRate(ctx, provider, providerToken.Symbol, currency.Code)
 		if err != nil {
-			logger.Errorf("Failed to get rate for provider %s", provider.ID)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"ProviderID": provider.ID,
+				"Token": tokenPayload.Symbol,
+				"Currency": tokenPayload.Currency,
+			}).Errorf("Failed to get rate for provider during update")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to update profile", nil)
 			return
 		}
@@ -455,13 +469,21 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 					Save(ctx)
 				if err != nil {
 					tx.Rollback()
-					logger.Errorf("Failed to create token: %v", err)
-					u.APIResponse(ctx, http.StatusInternalServerError, "error", fmt.Sprintf("Failed to create token - %s", tokenPayload.Symbol), nil)
+					logger.WithFields(logger.Fields{
+						"Error": err,
+						"Token": tokenPayload.Symbol,
+						"Currency": tokenPayload.Currency,
+					}).Errorf("Failed to create token during update")
+					u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to update profile", nil)
 					return
 				}
 			} else {
 				tx.Rollback()
-				logger.Errorf("Failed to query token: %v %s", err, tokenPayload.Symbol)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"Token": tokenPayload.Symbol,
+					"Currency": tokenPayload.Currency,
+				}).Errorf("Failed to query token during update")
 				u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to update profile", nil)
 				return
 			}
@@ -491,8 +513,11 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 			_, err = update.Save(ctx)
 			if err != nil {
 				tx.Rollback()
-				fmt.Println("error", err)
-				logger.Errorf("Failed to update token: %v %s", err, tokenPayload.Symbol)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"Token": tokenPayload.Symbol,
+					"Currency": tokenPayload.Currency,
+				}).Errorf("Failed to update token during update")
 				u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to update profile", nil)
 				return
 			}
@@ -517,7 +542,12 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 			).
 			All(ctx)
 		if err != nil {
-			logger.Errorf("Failed to assign provider %s to buckets", provider.ID)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"ProviderID": provider.ID,
+				"MinAmount": tokenPayload.MinOrderAmount,
+				"MaxAmount": tokenPayload.MaxOrderAmount,
+			}).Errorf("Failed to assign provider to buckets")
 		} else {
 			update.ClearProvisionBuckets()
 			update.AddProvisionBuckets(buckets...)
@@ -531,7 +561,10 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 
 	_, err := update.Save(ctx)
 	if err != nil {
-		logger.Errorf("Failed to commit update of provider profile: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"ProviderID": provider.ID,
+		}).Errorf("Failed to commit update of provider profile")
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to update profile", nil)
 		return
 	}
@@ -551,7 +584,7 @@ func (ctrl *ProfileController) GetSenderProfile(ctx *gin.Context) {
 
 	user, err := sender.QueryUser().Only(ctx)
 	if err != nil {
-		logger.Errorf("error: %v", err)
+		logger.Errorf("Error: Failed to fetch sender profile for user %v", err)
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
 		return
 	}
@@ -559,7 +592,10 @@ func (ctrl *ProfileController) GetSenderProfile(ctx *gin.Context) {
 	// Get API key
 	apiKey, err := ctrl.apiKeyService.GetAPIKey(ctx, sender, nil)
 	if err != nil {
-		logger.Errorf("error: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"SenderID": sender.ID,
+		}).Errorf("Failed to fetch sender API key")
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
 		return
 	}
@@ -574,7 +610,10 @@ func (ctrl *ProfileController) GetSenderProfile(ctx *gin.Context) {
 		).
 		All(ctx)
 	if err != nil {
-		logger.Errorf("error: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"SenderID": sender.ID,
+		}).Errorf("Failed to fetch sender order tokens")
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
 		return
 	}
@@ -613,7 +652,10 @@ func (ctrl *ProfileController) GetSenderProfile(ctx *gin.Context) {
 		if ent.IsNotFound(err) {
 			// do nothing
 		} else {
-			logger.Errorf("error: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"SenderID": sender.ID,
+			}).Errorf("Failed to fetch linked providerf for sender")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
 			return
 		}
@@ -644,7 +686,7 @@ func (ctrl *ProfileController) GetProviderProfile(ctx *gin.Context) {
 
 	user, err := provider.QueryUser().Only(ctx)
 	if err != nil {
-		logger.Errorf("error: %v", err)
+		logger.Errorf("Error: Failed to fetch provider profile for user %v", err)
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
 		return
 	}
@@ -652,7 +694,10 @@ func (ctrl *ProfileController) GetProviderProfile(ctx *gin.Context) {
 	// Get currencies
 	currencies, err := provider.QueryCurrencies().All(ctx)
 	if err != nil {
-		logger.Errorf("error: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"ProviderID": provider.ID,
+		}).Errorf("Failed to fetch currencies for provider")
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
 		return
 	}
@@ -671,7 +716,10 @@ func (ctrl *ProfileController) GetProviderProfile(ctx *gin.Context) {
 	}
 	orderTokens, err := query.All(ctx)
 	if err != nil {
-		logger.Errorf("error: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"ProviderID": provider.ID,
+		}).Errorf("Failed to fetch order tokens for provider")
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
 		return
 	}
@@ -696,7 +744,10 @@ func (ctrl *ProfileController) GetProviderProfile(ctx *gin.Context) {
 	// Get API key
 	apiKey, err := ctrl.apiKeyService.GetAPIKey(ctx, nil, provider)
 	if err != nil {
-		logger.Errorf("error: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"ProviderID": provider.ID,
+		}).Errorf("Failed to fetch provider API key")
 		u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to retrieve profile", nil)
 		return
 	}

--- a/controllers/index.go
+++ b/controllers/index.go
@@ -63,7 +63,7 @@ func (ctrl *Controller) GetFiatCurrencies(ctx *gin.Context) {
 		logger.Errorf("Error: Failed to fetch fiat currencies: %v", err)
 
 		u.APIResponse(ctx, http.StatusBadRequest, "error",
-			"Failed to fetch FiatCurrencies", err.Error())
+			"Failed to fetch FiatCurrencies", fmt.Sprintf("%v", err))
 		return
 	}
 
@@ -210,7 +210,7 @@ func (ctrl *Controller) GetTokenRate(ctx *gin.Context) {
 					parts := strings.Split(providerData, ":")
 					if len(parts) != 5 {
 						logger.WithFields(logger.Fields{
-							"Error": err,
+							"Error": fmt.Sprintf("%v", err),
 							"ProviderData": providerData,
 							"Token": token.Symbol,
 							"Currency": currency.Code,
@@ -315,7 +315,7 @@ func (ctrl *Controller) VerifyAccount(ctx *gin.Context) {
 
 	if err := ctx.ShouldBindJSON(&payload); err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Institution": payload.Institution,
 			"AccountIdentifier": payload.AccountIdentifier,
 		}).Errorf("Failed to validate payload when verifying account")
@@ -335,7 +335,7 @@ func (ctrl *Controller) VerifyAccount(ctx *gin.Context) {
 		Only(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Institution": payload.Institution,
 			"AccountIdentifier": payload.AccountIdentifier,
 		}).Errorf("Failed to validate payload when verifying account")
@@ -366,7 +366,7 @@ func (ctrl *Controller) VerifyAccount(ctx *gin.Context) {
 		All(ctx)
 	if err != nil {
 		u.APIResponse(ctx, http.StatusBadRequest, "error",
-			"Failed to verify account", err.Error())
+			"Failed to verify account", fmt.Sprintf("%v", err))
 		return
 	}
 
@@ -390,7 +390,7 @@ func (ctrl *Controller) VerifyAccount(ctx *gin.Context) {
 
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Institution": payload.Institution,
 			"AccountIdentifier": payload.AccountIdentifier,
 			"AccountName": data["data"].(string),
@@ -430,7 +430,7 @@ func (ctrl *Controller) GetLockPaymentOrderStatus(ctx *gin.Context) {
 		All(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"OrderID": orderID,
 			"ChainID": chainID,
 		}).Errorf("Failed to fetch locked order status")
@@ -508,7 +508,7 @@ func (ctrl *Controller) CreateLinkedAddress(ctx *gin.Context) {
 
 	if err := ctx.ShouldBindJSON(&payload); err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Institution": payload.Institution,
 			"AccountIdentifier": payload.AccountIdentifier,
 			"AccountName": payload.AccountName,
@@ -540,7 +540,7 @@ func (ctrl *Controller) CreateLinkedAddress(ctx *gin.Context) {
 		Save(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Institution": payload.Institution,
 			"AccountIdentifier": payload.AccountIdentifier,
 			"OwnerAddress": ownerAddress,
@@ -577,7 +577,7 @@ func (ctrl *Controller) GetLinkedAddress(ctx *gin.Context) {
 			return
 		} else {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OwnerAddress": owner_address,
 			}).Errorf("Failed to fetch linked address")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to fetch linked address", nil)
@@ -592,7 +592,7 @@ func (ctrl *Controller) GetLinkedAddress(ctx *gin.Context) {
 		Only(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"OwnerAddress": owner_address,
 			"LinkedAddressInstitution": linkedAddress.Institution,
 		}).Errorf("Failed to fetch linked address")
@@ -633,7 +633,7 @@ func (ctrl *Controller) GetLinkedAddressTransactions(ctx *gin.Context) {
 			return
 		} else {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"LinkedAddress": linked_address,
 			}).Errorf("Failed to fetch linked address")
 			u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to fetch linked address", nil)
@@ -650,7 +650,7 @@ func (ctrl *Controller) GetLinkedAddressTransactions(ctx *gin.Context) {
 	count, err := paymentOrderQuery.Count(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"LinkedAddress": linked_address,
 			"LinkedAddressID": linkedAddress.ID,
 			"LinkedAddressOwnerAddress": linkedAddress.OwnerAddress,
@@ -669,7 +669,7 @@ func (ctrl *Controller) GetLinkedAddressTransactions(ctx *gin.Context) {
 		All(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"LinkedAddress": linked_address,
 			"LinkedAddressID": linkedAddress.ID,
 			"LinkedAddressOwnerAddress": linkedAddress.OwnerAddress,
@@ -688,7 +688,7 @@ func (ctrl *Controller) GetLinkedAddressTransactions(ctx *gin.Context) {
 			Only(ctx)
 		if err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"LinkedAddress": linked_address,
 				"LinkedAddressID": linkedAddress.ID,
 				"LinkedAddressOwnerAddress": linkedAddress.OwnerAddress,
@@ -741,24 +741,24 @@ func (ctrl *Controller) RequestIDVerification(ctx *gin.Context) {
 
 	response, err := ctrl.kycService.RequestVerification(ctx, payload)
 	if err != nil {
-		switch err.Error() {
+		switch fmt.Sprintf("%v", err) {
 			case "invalid signature", "invalid signature: signature is not in the correct format",
 			"invalid signature: signature length is not correct",
 			"invalid signature: invalid recovery ID":
-			u.APIResponse(ctx, http.StatusBadRequest, "error", "Invalid signature", err.Error())
+			u.APIResponse(ctx, http.StatusBadRequest, "error", "Invalid signature", fmt.Sprintf("%v", err))
 			return
 		case "signature already used for identity verification":
 			u.APIResponse(ctx, http.StatusBadRequest, "error", "Signature already used for identity verification", nil)
 			return
 		case "this account has already been successfully verified":
-			u.APIResponse(ctx, http.StatusBadRequest, "success", "Failed to request identity verification", err.Error())
+			u.APIResponse(ctx, http.StatusBadRequest, "success", "Failed to request identity verification", fmt.Sprintf("%v", err))
 			return
 		case "failed to request identity verification: couldn't reach identity provider":
 			u.APIResponse(ctx, http.StatusServiceUnavailable, "error", "Failed to request identity verification", "Couldn't reach identity provider")
 			return
 		default:
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"WalletAddress": payload.WalletAddress,
 				"Nonce": payload.Nonce,
 			}).Errorf("Failed to request identity verification")
@@ -779,10 +779,10 @@ func (ctrl *Controller) GetIDVerificationStatus(ctx *gin.Context) {
 	response, err := ctrl.kycService.CheckStatus(ctx, walletAddress)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"WalletAddress": walletAddress,
 		}).Errorf("Failed to fetch identity verification status")
-		if err.Error() == "no verification request found for this wallet address" {
+		if fmt.Sprintf("%v", err) == "no verification request found for this wallet address" {
 			u.APIResponse(ctx, http.StatusNotFound, "error", "No verification request found for this wallet address", nil)
 			return
 		}
@@ -805,14 +805,14 @@ func (ctrl *Controller) KYCWebhook(ctx *gin.Context) {
 	err = ctrl.kycService.HandleWebhook(ctx, payload)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Payload": string(payload),
 		}).Errorf("Failed to process webhook for kyc")
-		if err.Error() == "invalid payload" {
+		if fmt.Sprintf("%v", err) == "invalid payload" {
 			ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid payload"})
 			return
 		}
-		if err.Error() == "invalid signature" {
+		if fmt.Sprintf("%v", err) == "invalid signature" {
 			ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid signature"})
 			return
 		}

--- a/controllers/index.go
+++ b/controllers/index.go
@@ -393,7 +393,6 @@ func (ctrl *Controller) VerifyAccount(ctx *gin.Context) {
 			"Error": fmt.Sprintf("%v", err),
 			"Institution": payload.Institution,
 			"AccountIdentifier": payload.AccountIdentifier,
-			"AccountName": data["data"].(string),
 		}).Errorf("Failed to verify account")
 		u.APIResponse(ctx, http.StatusServiceUnavailable, "error", "Failed to verify account", nil)
 		return
@@ -511,7 +510,6 @@ func (ctrl *Controller) CreateLinkedAddress(ctx *gin.Context) {
 			"Error": fmt.Sprintf("%v", err),
 			"Institution": payload.Institution,
 			"AccountIdentifier": payload.AccountIdentifier,
-			"AccountName": payload.AccountName,
 		}).Errorf("Failed to validate payload when creating linked address")
 		u.APIResponse(ctx, http.StatusBadRequest, "error",
 			"Failed to validate payload", u.GetErrorData(err))
@@ -542,7 +540,6 @@ func (ctrl *Controller) CreateLinkedAddress(ctx *gin.Context) {
 		logger.WithFields(logger.Fields{
 			"Error": fmt.Sprintf("%v", err),
 			"Institution": payload.Institution,
-			"AccountIdentifier": payload.AccountIdentifier,
 			"OwnerAddress": ownerAddress,
 			"Address": address,
 		}).Errorf("Failed to set linked address")

--- a/main.go
+++ b/main.go
@@ -36,6 +36,13 @@ func main() {
 		logger.Fatalf("Redis initialization: %v", err)
 	}
 
+	// Log Redis initialization with detailed context - file, line, function added automatically
+	logger.WithFields(logger.Fields{
+		"service":   "redis",
+		"status":    "initialized",
+		"timestamp": time.Now().Format(time.RFC3339),
+	}).Errorf("Redis service initialized successfully")
+
 	// Subscribe to Redis keyspace events
 	tasks.SubscribeToRedisKeyspaceEvents()
 

--- a/main.go
+++ b/main.go
@@ -36,13 +36,6 @@ func main() {
 		logger.Fatalf("Redis initialization: %v", err)
 	}
 
-	// Log Redis initialization with detailed context - file, line, function added automatically
-	logger.WithFields(logger.Fields{
-		"service":   "redis",
-		"status":    "initialized",
-		"timestamp": time.Now().Format(time.RFC3339),
-	}).Errorf("Redis service initialized successfully")
-
 	// Subscribe to Redis keyspace events
 	tasks.SubscribeToRedisKeyspaceEvents()
 

--- a/services/email.go
+++ b/services/email.go
@@ -164,13 +164,13 @@ func SendTemplateEmail(content types.SendEmailPayload, templateId string) (types
 		Body().AsJSON(reqBody).
 		Send()
 	if err != nil {
-		logger.Errorf("error sending request: %v", err)
+		logger.Errorf("Failed to send Email: %v", err)
 		return types.SendEmailResponse{}, fmt.Errorf("error sending request: %w", err)
 	}
 
 	data, err := utils.ParseJSONResponse(res.RawResponse)
 	if err != nil {
-		logger.Errorf("error parsing response: %v %v", err, data)
+		logger.Errorf("Failed to decode %v response after sending Email: %v", data, err)
 		return types.SendEmailResponse{}, fmt.Errorf("error parsing response: %w", err)
 	}
 
@@ -215,13 +215,13 @@ func SendTemplateEmailWithJsonAttachment(content types.SendEmailPayload, templat
 		Body().AsJSON(reqBody).
 		Send()
 	if err != nil {
-		logger.Errorf("error sending request: %v", err)
+		logger.Errorf("Failed to send Email with JSON attachment: %v", err)
 		return fmt.Errorf("error sending request: %w", err)
 	}
 
 	data, err := utils.ParseJSONResponse(res.RawResponse)
 	if err != nil {
-		logger.Errorf("error parsing response: %v %v", err, data)
+		logger.Errorf("Failed to decode %v response after sending Email with JSON attachment: %v", data, err)
 		return fmt.Errorf("error parsing response: %w", err)
 	}
 

--- a/services/indexer.go
+++ b/services/indexer.go
@@ -336,7 +336,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 			if err != nil {
 				logger.WithFields(logger.Fields{
 					"Error": fmt.Sprintf("%v", err),
-					"OrderID": order.ID,
+					"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 				}).Errorf("Failed to create order when indexing ERC20 transfers for %s", token.Edges.Network.Identifier)
 				continue
 			}
@@ -348,7 +348,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 				if !strings.Contains(fmt.Sprintf("%v", err), "Duplicate payment order") {
 					logger.WithFields(logger.Fields{
 						"Error": fmt.Sprintf("%v", err),
-						"OrderID": order.ID,
+						"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 					}).Errorf("Failed to update receive address status when indexing ERC20 transfers for %s", token.Edges.Network.Identifier)
 				}
 				continue
@@ -382,7 +382,7 @@ func (s *IndexerService) IndexTRC20Transfer(ctx context.Context, order *ent.Paym
 	if err != nil {
 		logger.WithFields(logger.Fields{
 			"Error": fmt.Sprintf("%v", err),
-			"OrderID": order.ID,
+			"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 		}).Errorf("Failed to fetch TRC20 transfer for %s", order.Edges.Token.Edges.Network.Identifier)
 		return err
 	}
@@ -451,7 +451,7 @@ func (s *IndexerService) IndexTRC20Transfer(ctx context.Context, order *ent.Paym
 					if err != nil {
 						logger.WithFields(logger.Fields{
 							"Error": fmt.Sprintf("%v", err),
-							"OrderID": order.ID,
+							"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 						}).Errorf("Failed to update receive address status when indexing TRC20 transfers for %s", order.Edges.Token.Edges.Network.Identifier)
 					}
 				}()
@@ -532,7 +532,7 @@ func (s *IndexerService) IndexOrderCreated(ctx context.Context, client types.RPC
 			if !strings.Contains(fmt.Sprintf("%v", err), "duplicate key value violates unique constraint") {
 				logger.WithFields(logger.Fields{
 					"Error": fmt.Sprintf("%v", err),
-					"OrderID": event.OrderId,
+					"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(event.OrderId[:])),
 				}).Errorf("Failed to create lock payment order when indexing order created events for %s", network.Identifier)
 			}
 			continue
@@ -607,7 +607,7 @@ func (s *IndexerService) IndexOrderCreatedTron(ctx context.Context, order *ent.P
 					if err != nil {
 						logger.WithFields(logger.Fields{
 							"Error": fmt.Sprintf("%v", err),
-							"OrderID": event.OrderId,
+							"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(event.OrderId[:])),
 						}).Errorf("Failed to create lock payment order when indexing order created events for %s", order.Edges.Token.Edges.Network.Identifier)
 					}
 
@@ -685,7 +685,7 @@ func (s *IndexerService) IndexOrderSettled(ctx context.Context, client types.RPC
 		if err != nil {
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
-				"OrderID": settledEvent.OrderId,
+				"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(settledEvent.OrderId[:])),
 			}).Errorf("Failed to update order status settlement when indexing order created events for %s", network.Identifier)
 			continue
 		}
@@ -745,7 +745,7 @@ func (s *IndexerService) IndexOrderSettledTron(ctx context.Context, order *ent.L
 					if err != nil {
 						logger.WithFields(logger.Fields{
 							"Error": fmt.Sprintf("%v", err),
-							"OrderID": order.ID,
+							"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 						}).Errorf("Failed to unpack event data for %s", order.Edges.Token.Edges.Network.Identifier)
 						return err
 					}
@@ -763,7 +763,7 @@ func (s *IndexerService) IndexOrderSettledTron(ctx context.Context, order *ent.L
 					if err != nil {
 						logger.WithFields(logger.Fields{
 							"Error": fmt.Sprintf("%v", err),
-							"OrderID": order.ID,
+							"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 						}).Errorf("Failed to update order status settlement when indexing order created events for %s", order.Edges.Token.Edges.Network.Identifier)
 					}
 
@@ -839,7 +839,7 @@ func (s *IndexerService) IndexOrderRefunded(ctx context.Context, client types.RP
 		if err != nil {
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
-				"OrderID": refundedEvent.OrderId,
+				"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(refundedEvent.OrderId[:])),
 				"TxHash": refundedEvent.TxHash,
 			}).Errorf("Failed to update order status refund when indexing order created events for %s", network.Identifier)
 			continue
@@ -916,7 +916,7 @@ func (s *IndexerService) IndexOrderRefundedTron(ctx context.Context, order *ent.
 					if err != nil {
 						logger.WithFields(logger.Fields{
 							"Error": fmt.Sprintf("%v", err),
-							"OrderID": event.OrderId,
+							"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(event.OrderId[:])),
 							"TxHash": event.TxHash,
 						}).Errorf("Failed to update order status refund when indexing order created events for %s", order.Edges.Token.Edges.Network.Identifier)
 					}
@@ -1328,7 +1328,7 @@ func (s *IndexerService) handleCancellation(ctx context.Context, client types.RP
 		if err != nil {
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
-				"OrderID": order.ID,
+				"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 				"OrderTrxHash": order.TxHash,
 				"GatewayID": order.GatewayID,
 			}).Errorf("Handle cancellation failed to refund order")
@@ -1357,7 +1357,7 @@ func (s *IndexerService) handleCancellation(ctx context.Context, client types.RP
 		if err != nil {
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
-				"OrderID": createdLockPaymentOrder.ID,
+				"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(createdLockPaymentOrder.ID[:])),
 				"OrderTrxHash": createdLockPaymentOrder.TxHash,
 				"GatewayID": createdLockPaymentOrder.GatewayID,
 			}).Errorf("Handle cancellation failed to refund order")

--- a/services/indexer.go
+++ b/services/indexer.go
@@ -98,7 +98,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 	if err != nil {
 		// Need to group by network
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Token": token.ContractAddress,
 			"ReceiveAddress": addressToWatch,
 		}).Errorf("Failed to index ERC20 transfers for %s", token.Edges.Network.Identifier)
@@ -141,7 +141,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 	}, nil, addresses)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Token": token.ContractAddress,
 			"ReceiveAddress": addressToWatch,
 			"StartBlock": startBlock,
@@ -173,7 +173,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 		if err != nil {
 			if !ent.IsNotFound(err) {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"Address": transferEvent.To,
 				}).Errorf("Failed to query linked address when indexing ERC20 transfers for %s", token.Edges.Network.Identifier)
 			}
@@ -213,7 +213,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 			institution, err := utils.GetInstitutionByCode(ctx, linkedAddress.Institution)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"LinkedAddress": linkedAddress.Address,
 					"LinkedAddressInstitution": linkedAddress.Institution,
 				}).Errorf("Failed to get institution when indexing ERC20 transfers for %s", token.Edges.Network.Identifier)
@@ -229,7 +229,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 				rateResponse, err = utils.GetTokenRateFromQueue(token.Symbol, orderAmount, institution.Edges.FiatCurrency.Code, institution.Edges.FiatCurrency.MarketRate)
 				if err != nil {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"Token": token.Symbol,
 						"LinkedAddressInstitution": linkedAddress.Institution,
 						"Code": institution.Edges.FiatCurrency.Code,
@@ -243,7 +243,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 			tx, err := db.Client.Tx(ctx)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"LinkedAddress": linkedAddress.Address,
 				}).Errorf("Failed to create transaction when indexing ERC20 transfers for %s", token.Edges.Network.Identifier)
 				continue
@@ -287,7 +287,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 				Save(ctx)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"LinkedAddress": linkedAddress.Address,
 				}).Errorf("Failed to create payment order when indexing ERC20 transfers for %s", token.Edges.Network.Identifier)
 				_ = tx.Rollback()
@@ -303,7 +303,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 				Save(ctx)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"LinkedAddress": linkedAddress.Address,
 				}).Errorf("Failed to create payment order recipient when indexing ERC20 transfers for %s", token.Edges.Network.Identifier)
 				_ = tx.Rollback()
@@ -317,7 +317,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 				Save(ctx)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"LinkedAddress": linkedAddress.Address,
 				}).Errorf("Failed to update linked address when indexing ERC20 transfers for %s", token.Edges.Network.Identifier)
 				_ = tx.Rollback()
@@ -326,7 +326,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 
 			if err := tx.Commit(); err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"LinkedAddress": linkedAddress.Address,
 				}).Errorf("Failed to commit transaction when indexing ERC20 transfers for %s", token.Edges.Network.Identifier)
 				continue
@@ -335,7 +335,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 			err = s.order.CreateOrder(ctx, client, order.ID)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"OrderID": order.ID,
 				}).Errorf("Failed to create order when indexing ERC20 transfers for %s", token.Edges.Network.Identifier)
 				continue
@@ -345,9 +345,9 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 			// Process transfer event for receive address
 			done, err := s.UpdateReceiveAddressStatus(ctx, client, order.Edges.ReceiveAddress, order, transferEvent)
 			if err != nil {
-				if !strings.Contains(err.Error(), "Duplicate payment order") {
+				if !strings.Contains(fmt.Sprintf("%v", err), "Duplicate payment order") {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"OrderID": order.ID,
 					}).Errorf("Failed to update receive address status when indexing ERC20 transfers for %s", token.Edges.Network.Identifier)
 				}
@@ -381,7 +381,7 @@ func (s *IndexerService) IndexTRC20Transfer(ctx context.Context, order *ent.Paym
 		Send()
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"OrderID": order.ID,
 		}).Errorf("Failed to fetch TRC20 transfer for %s", order.Edges.Token.Edges.Network.Identifier)
 		return err
@@ -390,7 +390,7 @@ func (s *IndexerService) IndexTRC20Transfer(ctx context.Context, order *ent.Paym
 	data, err := utils.ParseJSONResponse(res.RawResponse)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Response": data,
 		}).Errorf("Failed to parse JSON response for TRC20 transfer for %s", order.Edges.Token.Edges.Network.Identifier)
 		return err
@@ -403,7 +403,7 @@ func (s *IndexerService) IndexTRC20Transfer(ctx context.Context, order *ent.Paym
 			value, err := decimal.NewFromString(eventData["value"].(string))
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"Value": eventData["value"],
 				}).Errorf("Failed to parse decimal value from TRC20 transfer for %s", order.Edges.Token.Edges.Network.Identifier)
 				return err
@@ -422,7 +422,7 @@ func (s *IndexerService) IndexTRC20Transfer(ctx context.Context, order *ent.Paym
 				Send()
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"TransactionID": eventData["transaction_id"],
 				}).Errorf("Failed to fetch block number for TRC20 transfer for %s", order.Edges.Token.Edges.Network.Identifier)
 				return err
@@ -431,7 +431,7 @@ func (s *IndexerService) IndexTRC20Transfer(ctx context.Context, order *ent.Paym
 			data, err = utils.ParseJSONResponse(res.RawResponse)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"Response": data,
 				}).Errorf("Failed to parse JSON response for TRC20 transfer for %s", order.Edges.Token.Edges.Network.Identifier)
 				return err
@@ -450,7 +450,7 @@ func (s *IndexerService) IndexTRC20Transfer(ctx context.Context, order *ent.Paym
 					_, err := s.UpdateReceiveAddressStatus(ctx, nil, order.Edges.ReceiveAddress, order, transferEvent)
 					if err != nil {
 						logger.WithFields(logger.Fields{
-							"Error": err,
+							"Error": fmt.Sprintf("%v", err),
 							"OrderID": order.ID,
 						}).Errorf("Failed to update receive address status when indexing TRC20 transfers for %s", order.Edges.Token.Edges.Network.Identifier)
 					}
@@ -478,7 +478,7 @@ func (s *IndexerService) IndexOrderCreated(ctx context.Context, client types.RPC
 	filterer, err := contracts.NewGatewayFilterer(common.HexToAddress(network.GatewayContractAddress), client)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 		}).Errorf("Failed to create gateway filterer when indexing order created events for %s", network.Identifier)
 		return err
 	}
@@ -488,7 +488,7 @@ func (s *IndexerService) IndexOrderCreated(ctx context.Context, client types.RPC
 	if err != nil {
 		if err != context.Canceled {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 			}).Errorf("Failed to fetch current block header for %s when indexing order created events", network.Identifier)
 		}
 		return err
@@ -507,7 +507,7 @@ func (s *IndexerService) IndexOrderCreated(ctx context.Context, client types.RPC
 	}, nil, nil, nil)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Start": uint64(int64(toBlock) - fromBlock),
 			"End":   toBlock,
 		}).Errorf("Failed to filter order created events for %s when indexing order created events", network.Identifier)
@@ -529,9 +529,9 @@ func (s *IndexerService) IndexOrderCreated(ctx context.Context, client types.RPC
 
 		err := s.CreateLockPaymentOrder(ctx, client, network, event)
 		if err != nil {
-			if !strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
+			if !strings.Contains(fmt.Sprintf("%v", err), "duplicate key value violates unique constraint") {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"OrderID": event.OrderId,
 				}).Errorf("Failed to create lock payment order when indexing order created events for %s", network.Identifier)
 			}
@@ -566,7 +566,7 @@ func (s *IndexerService) IndexOrderCreatedTron(ctx context.Context, order *ent.P
 				Send()
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"TxHash": order.TxHash,
 				}).Errorf("Failed to fetch trx info by id for %s", order.Edges.Token.Edges.Network.Identifier)
 				return err
@@ -575,7 +575,7 @@ func (s *IndexerService) IndexOrderCreatedTron(ctx context.Context, order *ent.P
 			data, err := utils.ParseJSONResponse(res.RawResponse)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 				}).Errorf("Failed to parse JSON response for %s", order.Edges.Token.Edges.Network.Identifier)
 				return err
 			}
@@ -587,7 +587,7 @@ func (s *IndexerService) IndexOrderCreatedTron(ctx context.Context, order *ent.P
 					unpackedEventData, err := utils.UnpackEventData(eventData["data"].(string), contracts.GatewayMetaData.ABI, "OrderCreated")
 					if err != nil {
 						logger.WithFields(logger.Fields{
-							"Error": err,
+							"Error": fmt.Sprintf("%v", err),
 						}).Errorf("Failed to unpack event data for %s", order.Edges.Token.Edges.Network.Identifier)
 						return err
 					}
@@ -606,7 +606,7 @@ func (s *IndexerService) IndexOrderCreatedTron(ctx context.Context, order *ent.P
 					err = s.CreateLockPaymentOrder(ctx, nil, order.Edges.Token.Edges.Network, event)
 					if err != nil {
 						logger.WithFields(logger.Fields{
-							"Error": err,
+							"Error": fmt.Sprintf("%v", err),
 							"OrderID": event.OrderId,
 						}).Errorf("Failed to create lock payment order when indexing order created events for %s", order.Edges.Token.Edges.Network.Identifier)
 					}
@@ -638,7 +638,7 @@ func (s *IndexerService) IndexOrderSettled(ctx context.Context, client types.RPC
 	filterer, err := contracts.NewGatewayFilterer(common.HexToAddress(network.GatewayContractAddress), client)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 		}).Errorf("Failed to filterer when indexing order created events for %s", network.Identifier)
 		return err
 	}
@@ -648,7 +648,7 @@ func (s *IndexerService) IndexOrderSettled(ctx context.Context, client types.RPC
 	if err != nil {
 		if err != context.Canceled {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 			}).Errorf("Failed to fetch header by number when indexing order created events for %s", network.Identifier)
 		}
 		return err
@@ -663,7 +663,7 @@ func (s *IndexerService) IndexOrderSettled(ctx context.Context, client types.RPC
 	}, nil, nil)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Start": uint64(int64(toBlock) - 5000),
 			"End":   toBlock,
 		}).Errorf("Failed to filter order created events for %s when indexing order created events", network.Identifier)
@@ -684,7 +684,7 @@ func (s *IndexerService) IndexOrderSettled(ctx context.Context, client types.RPC
 		err := s.UpdateOrderStatusSettled(ctx, network, settledEvent)
 		if err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": settledEvent.OrderId,
 			}).Errorf("Failed to update order status settlement when indexing order created events for %s", network.Identifier)
 			continue
@@ -718,7 +718,7 @@ func (s *IndexerService) IndexOrderSettledTron(ctx context.Context, order *ent.L
 				Send()
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"TxHash": order.TxHash,
 				}).Errorf("Failed to fetch trx info by id for %s", order.Edges.Token.Edges.Network.Identifier)
 				return err
@@ -727,7 +727,7 @@ func (s *IndexerService) IndexOrderSettledTron(ctx context.Context, order *ent.L
 			data, err := utils.ParseJSONResponse(res.RawResponse)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 				}).Errorf("Failed to parse JSON response for %s", order.Edges.Token.Edges.Network.Identifier)
 				return err
 			}
@@ -744,7 +744,7 @@ func (s *IndexerService) IndexOrderSettledTron(ctx context.Context, order *ent.L
 					unpackedEventData, err := utils.UnpackEventData(eventData["data"].(string), contracts.GatewayMetaData.ABI, "OrderSettled")
 					if err != nil {
 						logger.WithFields(logger.Fields{
-							"Error": err,
+							"Error": fmt.Sprintf("%v", err),
 							"OrderID": order.ID,
 						}).Errorf("Failed to unpack event data for %s", order.Edges.Token.Edges.Network.Identifier)
 						return err
@@ -762,7 +762,7 @@ func (s *IndexerService) IndexOrderSettledTron(ctx context.Context, order *ent.L
 					err = s.UpdateOrderStatusSettled(ctx, order.Edges.Token.Edges.Network, event)
 					if err != nil {
 						logger.WithFields(logger.Fields{
-							"Error": err,
+							"Error": fmt.Sprintf("%v", err),
 							"OrderID": order.ID,
 						}).Errorf("Failed to update order status settlement when indexing order created events for %s", order.Edges.Token.Edges.Network.Identifier)
 					}
@@ -794,7 +794,7 @@ func (s *IndexerService) IndexOrderRefunded(ctx context.Context, client types.RP
 	filterer, err := contracts.NewGatewayFilterer(common.HexToAddress(network.GatewayContractAddress), client)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 		}).Errorf("Failed to filterer when indexing order created events for %s", network.Identifier)
 		return err
 	}
@@ -804,7 +804,7 @@ func (s *IndexerService) IndexOrderRefunded(ctx context.Context, client types.RP
 	if err != nil {
 		if err != context.Canceled {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 			}).Errorf("Failed to fetch header by number when indexing order created events for %s", network.Identifier)
 		}
 		return err
@@ -819,7 +819,7 @@ func (s *IndexerService) IndexOrderRefunded(ctx context.Context, client types.RP
 	}, nil)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Start": uint64(int64(toBlock) - 5000),
 			"End":   toBlock,
 		}).Errorf("Failed to filter order created events for %s when indexing order created events", network.Identifier)
@@ -838,7 +838,7 @@ func (s *IndexerService) IndexOrderRefunded(ctx context.Context, client types.RP
 		err := s.UpdateOrderStatusRefunded(ctx, network, refundedEvent)
 		if err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": refundedEvent.OrderId,
 				"TxHash": refundedEvent.TxHash,
 			}).Errorf("Failed to update order status refund when indexing order created events for %s", network.Identifier)
@@ -873,7 +873,7 @@ func (s *IndexerService) IndexOrderRefundedTron(ctx context.Context, order *ent.
 				Send()
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"TxHash": order.TxHash,
 				}).Errorf("Failed to fetch event logs for %s", order.Edges.Token.Edges.Network.Identifier)
 				return err
@@ -882,7 +882,7 @@ func (s *IndexerService) IndexOrderRefundedTron(ctx context.Context, order *ent.
 			data, err := utils.ParseJSONResponse(res.RawResponse)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"Response": data,
 				}).Errorf("Failed to parse JSON response for %s after fetching event logs", order.Edges.Token.Edges.Network.Identifier)
 				return err
@@ -900,7 +900,7 @@ func (s *IndexerService) IndexOrderRefundedTron(ctx context.Context, order *ent.
 					unpackedEventData, err := utils.UnpackEventData(eventData["data"].(string), contracts.GatewayMetaData.ABI, "OrderRefunded")
 					if err != nil {
 						logger.WithFields(logger.Fields{
-							"Error": err,
+							"Error": fmt.Sprintf("%v", err),
 						}).Errorf("Failed to unpack event data for %s after fetching event logs", order.Edges.Token.Edges.Network.Identifier)
 						return err
 					}
@@ -915,7 +915,7 @@ func (s *IndexerService) IndexOrderRefundedTron(ctx context.Context, order *ent.
 					err = s.UpdateOrderStatusRefunded(ctx, order.Edges.Token.Edges.Network, event)
 					if err != nil {
 						logger.WithFields(logger.Fields{
-							"Error": err,
+							"Error": fmt.Sprintf("%v", err),
 							"OrderID": event.OrderId,
 							"TxHash": event.TxHash,
 						}).Errorf("Failed to update order status refund when indexing order created events for %s", order.Edges.Token.Edges.Network.Identifier)
@@ -1081,7 +1081,7 @@ func (s *IndexerService) CreateLockPaymentOrder(ctx context.Context, client type
 	provisionBucket, isLessThanMin, err := s.getProvisionBucket(ctx, amountInDecimals.Mul(rate), currency)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Amount": amountInDecimals,
 			"Currency": currency,
 		}).Errorf("failed to fetch provision bucket when creating lock payment order")
@@ -1260,7 +1260,7 @@ func (s *IndexerService) CreateLockPaymentOrder(ctx context.Context, client type
 			ok, err := s.checkAMLCompliance(network.RPCEndpoint, event.TxHash)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"endpoint": network.RPCEndpoint,
 					"TxHash": event.TxHash,
 				}).Errorf("Failed to check AML Compliance")
@@ -1327,7 +1327,7 @@ func (s *IndexerService) handleCancellation(ctx context.Context, client types.RP
 		err = s.order.RefundOrder(ctx, client, network, lockPaymentOrder.GatewayID)
 		if err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": order.ID,
 				"OrderTrxHash": order.TxHash,
 				"GatewayID": order.GatewayID,
@@ -1356,7 +1356,7 @@ func (s *IndexerService) handleCancellation(ctx context.Context, client types.RP
 		err = s.order.RefundOrder(ctx, client, network, createdLockPaymentOrder.GatewayID)
 		if err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": createdLockPaymentOrder.ID,
 				"OrderTrxHash": createdLockPaymentOrder.TxHash,
 				"GatewayID": createdLockPaymentOrder.GatewayID,
@@ -1849,7 +1849,7 @@ func (s *IndexerService) fetchLatestOrderEvents(rpcEndpoint, network, txHash str
 		Send()
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"TxHash": txHash,
 		}).Errorf("Failed to fetch txn event logs for %s", network)
 		return nil, err
@@ -1858,7 +1858,7 @@ func (s *IndexerService) fetchLatestOrderEvents(rpcEndpoint, network, txHash str
 	data, err := utils.ParseJSONResponse(res.RawResponse)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Response": data,
 		}).Errorf("Failed to parse JSON response for %s after fetching event logs", network)
 		return nil, err
@@ -1921,7 +1921,7 @@ func (s *IndexerService) splitLockPaymentOrder(ctx context.Context, client types
 		All(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Currency": currency.ID,
 			"CurrencyCode": currency.Code,
 			"CurrencEnabled": currency.IsEnabled,
@@ -1982,7 +1982,7 @@ func (s *IndexerService) splitLockPaymentOrder(ctx context.Context, client types
 			Save(ctx)
 		if err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": lockPaymentOrder.GatewayID,
 			}).Errorf("Failed to create lock payment order in Bulk when splitting lock payment order")
 			_ = tx.Rollback()
@@ -1992,7 +1992,7 @@ func (s *IndexerService) splitLockPaymentOrder(ctx context.Context, client types
 		// Commit the transaction if everything succeeded
 		if err := tx.Commit(); err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": lockPaymentOrder.GatewayID,
 			}).Errorf("Failed to commit transaction when splitting lock payment order")
 			return err
@@ -2003,7 +2003,7 @@ func (s *IndexerService) splitLockPaymentOrder(ctx context.Context, client types
 			ok, err := s.checkAMLCompliance(lockPaymentOrder.Network.RPCEndpoint, lockPaymentOrder.TxHash)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"endpoint": lockPaymentOrder.Network.RPCEndpoint,
 					"TxHash": lockPaymentOrder.TxHash,
 				}).Errorf("Failed to check AML Compliance")
@@ -2014,7 +2014,7 @@ func (s *IndexerService) splitLockPaymentOrder(ctx context.Context, client types
 				err := s.handleCancellation(ctx, client, ordersCreated[0], nil, "AML compliance check failed")
 				if err != nil {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"OrderID": ordersCreated[0].ID,
 						"OrderGatewayID": ordersCreated[0].GatewayID,
 						"Reason": "AML compliance check failed",
@@ -2062,7 +2062,7 @@ func (s *IndexerService) splitLockPaymentOrder(ctx context.Context, client types
 		orderCreated, err := orderCreatedUpdate.Save(ctx)
 		if err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": lockPaymentOrder.GatewayID,
 			}).Errorf("Failed to create lock payment order when splitting lock payment order")
 			return err

--- a/services/priority_queue.go
+++ b/services/priority_queue.go
@@ -140,13 +140,19 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 	// Delete the previous queue
 	err := s.deleteQueue(ctx, prevRedisKey)
 	if err != nil && err != context.Canceled {
-		logger.Errorf("failed to delete previous provider queue: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"Key": prevRedisKey,
+		}).Errorf("failed to delete previous provider queue")
 	}
 
 	// Copy the current queue to the previous queue
 	prevData, err := storage.RedisClient.LRange(ctx, redisKey, 0, -1).Result()
 	if err != nil && err != context.Canceled {
-		logger.Errorf("failed to fetch provider rates: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"Key": redisKey,
+		}).Errorf("failed to fetch provider rates")
 	}
 
 	// Convert []string to []interface{}
@@ -159,14 +165,21 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 	if len(prevValues) > 0 {
 		err = storage.RedisClient.RPush(ctx, prevRedisKey, prevValues...).Err()
 		if err != nil && err != context.Canceled {
-			logger.Errorf("failed to store previous provider rates: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"Key": prevRedisKey,
+				"Values": prevValues,
+			}).Errorf("failed to store previous provider rates")
 		}
 	}
 
 	// Delete the current queue
 	err = s.deleteQueue(ctx, redisKey)
 	if err != nil && err != context.Canceled {
-		logger.Errorf("failed to delete existing circular queue: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"Key": redisKey,
+		}).Errorf("failed to delete existing circular queue")
 	}
 
 	// TODO: add also the checks for all the currencies that a provider has
@@ -188,7 +201,11 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 			All(ctx)
 		if err != nil {
 			if err != context.Canceled {
-				logger.Errorf("failed to get tokens for provider %s: %v", provider.ID, err)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"ProviderID": provider.ID,
+					"Currency": bucket.Edges.Currency.Code,
+				}).Errorf("failed to get tokens for provider")
 			}
 			continue
 		}
@@ -203,7 +220,12 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 			rate, err := s.GetProviderRate(ctx, provider, orderToken.Edges.Token.Symbol, bucket.Edges.Currency.Code)
 			if err != nil {
 				if err != context.Canceled {
-					logger.Errorf("failed to get %s rate for provider %s: %v", orderToken.Edges.Token.Symbol, provider.ID, err)
+					logger.WithFields(logger.Fields{
+						"Error": err,
+						"ProviderID": provider.ID,
+						"Token": orderToken.Edges.Token.Symbol,
+						"Currency": bucket.Edges.Currency.Code,
+					}).Errorf("failed to get rate for provider")
 				}
 				continue
 			}
@@ -228,7 +250,11 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 			// Enqueue the serialized data into the circular queue
 			err = storage.RedisClient.RPush(ctx, redisKey, data).Err()
 			if err != nil && err != context.Canceled {
-				logger.Errorf("failed to enqueue provider data to circular queue: %v", err)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"Key": redisKey,
+					"Data": data,
+				}).Errorf("failed to enqueue provider data to circular queue")
 			}
 		}
 	}
@@ -240,7 +266,11 @@ func (s *PriorityQueueService) AssignLockPaymentOrder(ctx context.Context, order
 
 	excludeList, err := storage.RedisClient.LRange(ctx, fmt.Sprintf("order_exclude_list_%s", order.ID), 0, -1).Result()
 	if err != nil {
-		logger.Errorf("%s - failed to get exclude list: %v", order.ID, err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"OrderID": order.ID,
+			"ProviderID": order.ProviderID,
+		}).Errorf("failed to get exclude list")
 		return err
 	}
 
@@ -260,7 +290,11 @@ func (s *PriorityQueueService) AssignLockPaymentOrder(ctx context.Context, order
 			if order.UpdatedAt.Before(time.Now().Add(-10 * time.Minute)) {
 				order.Rate, err = s.GetProviderRate(ctx, provider, order.Token.Symbol, order.ProvisionBucket.Edges.Currency.Code)
 				if err != nil {
-					logger.Errorf("%s - failed to get rate for provider %s: %v", orderIDPrefix, order.ProviderID, err)
+					logger.WithFields(logger.Fields{
+						"Error": err,
+						"OrderID": order.ID,
+						"ProviderID": order.ProviderID,
+					}).Errorf("failed to get rate for provider")
 				}
 				_, err = storage.Client.PaymentOrder.
 					Update().
@@ -268,16 +302,28 @@ func (s *PriorityQueueService) AssignLockPaymentOrder(ctx context.Context, order
 					SetRate(order.Rate).
 					Save(ctx)
 				if err != nil {
-					logger.Errorf("%s - failed to update rate for provider %s: %v", orderIDPrefix, order.ProviderID, err)
+					logger.WithFields(logger.Fields{
+						"Error": err,
+						"OrderID": order.ID,
+						"ProviderID": order.ProviderID,
+					}).Errorf("failed to update rate for provider")
 				}
 			}
 			err = s.sendOrderRequest(ctx, order)
 			if err == nil {
 				return nil
 			}
-			logger.Errorf("%s - failed to send order request to specific provider %s: %v", orderIDPrefix, order.ProviderID, err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"OrderID": order.ID,
+				"ProviderID": order.ProviderID,
+			}).Errorf("failed to send order request to specific provider")
 		} else {
-			logger.Errorf("%s - failed to get provider: %v", orderIDPrefix, err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"OrderID": order.ID,
+				"ProviderID": order.ProviderID,
+			}).Errorf("failed to get provider")
 		}
 
 		if provider.VisibilityMode == providerprofile.VisibilityModePrivate {
@@ -315,21 +361,34 @@ func (s *PriorityQueueService) sendOrderRequest(ctx context.Context, order types
 	}
 
 	if err := storage.RedisClient.HSet(ctx, orderKey, orderRequestData).Err(); err != nil {
-		logger.Errorf("failed to map order to a provider in Redis: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"OrderID": order.ID,
+			"ProviderID": order.ProviderID,
+			"orderKey": orderKey,
+		}).Errorf("failed to map order to a provider in Redis")
 		return err
 	}
 
 	// Set a TTL for the order request
 	err := storage.RedisClient.ExpireAt(ctx, orderKey, time.Now().Add(orderConf.OrderRequestValidity)).Err()
 	if err != nil {
-		logger.Errorf("failed to set TTL for order request: %v", err)
+		// logger.Errorf("failed to set TTL for order request: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"orderKey": orderKey,
+		}).Errorf("failed to set TTL for order request")
 		return err
 	}
 
 	// Notify the provider
 	orderRequestData["orderId"] = order.ID
 	if err := s.notifyProvider(ctx, orderRequestData); err != nil {
-		logger.Errorf("failed to notify provider %s: %v", order.ProviderID, err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"OrderID": order.ID,
+			"ProviderID": order.ProviderID,
+		}).Errorf("failed to notify provider")
 		return err
 	}
 
@@ -377,7 +436,11 @@ func (s *PriorityQueueService) notifyProvider(ctx context.Context, orderRequestD
 
 	data, err := utils.ParseJSONResponse(res.RawResponse)
 	if err != nil {
-		logger.Errorf("PriorityQueueService.notifyProvider: %v %v", err, data)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"ProviderID": providerID,
+		}).Errorf("failed to parse JSON response after new order request with data: %v", data)
+		return err
 	}
 
 	return nil
@@ -408,7 +471,12 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 		// Extract the rate from the data (assuming it's in the format "providerID:token:rate:minAmount:maxAmount")
 		parts := strings.Split(providerData, ":")
 		if len(parts) != 5 {
-			logger.Errorf("%s - invalid data format at index %d: %s", orderIDPrefix, index, providerData)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"OrderID": order.ID,
+				"ProviderID": order.ProviderID,
+				"ProviderData": providerData,
+			}).Errorf("invalid data format at index %d when matching rate", index)
 			continue // Skip this entry due to invalid format
 		}
 
@@ -482,14 +550,26 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 				// Match found at index 0, perform LPOP to dequeue
 				data, err := storage.RedisClient.LPop(ctx, redisKey).Result()
 				if err != nil {
-					logger.Errorf("%s - failed to dequeue from circular queue: %v", orderIDPrefix, err)
+					logger.WithFields(logger.Fields{
+						"Error": err,
+						"OrderID": order.ID,
+						"ProviderID": order.ProviderID,
+						"redisKey": redisKey,
+						"orderIDPrefix": orderIDPrefix,
+					}).Errorf("failed to dequeue from circular queue when matching rate")
 					return err
 				}
 
 				// Enqueue data to the end of the queue
 				err = storage.RedisClient.RPush(ctx, redisKey, data).Err()
 				if err != nil {
-					logger.Errorf("%s - failed to enqueue to circular queue: %v", orderIDPrefix, err)
+					logger.WithFields(logger.Fields{
+						"Error": err,
+						"OrderID": order.ID,
+						"ProviderID": order.ProviderID,
+						"redisKey": redisKey,
+						"orderIDPrefix": orderIDPrefix,
+					}).Errorf("failed to enqueue to circular queue when matching rate")
 					return err
 				}
 			}
@@ -497,13 +577,25 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 			// Assign the order to the provider and save it to Redis
 			err = s.sendOrderRequest(ctx, order)
 			if err != nil {
-				logger.Errorf("%s - failed to send order request to specific provider %s: %v", orderIDPrefix, order.ProviderID, err)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"OrderID": order.ID,
+					"ProviderID": order.ProviderID,
+					"redisKey": redisKey,
+					"orderIDPrefix": orderIDPrefix,
+				}).Errorf("failed to send order request to specific provider when matching rate")
 
 				// Push provider ID to order exclude list
 				orderKey := fmt.Sprintf("order_exclude_list_%s", order.ID)
 				_, err = storage.RedisClient.RPush(ctx, orderKey, order.ProviderID).Result()
 				if err != nil {
-					logger.Errorf("%s - error pushing provider %s to order_exclude_list on Redis: %v", orderIDPrefix, order.ProviderID, err)
+					logger.WithFields(logger.Fields{
+						"Error": err,
+						"OrderID": order.ID,
+						"ProviderID": order.ProviderID,
+						"redisKey": redisKey,
+						"orderIDPrefix": orderIDPrefix,
+					}).Errorf("failed to push provider to order exclude list when matching rate")
 				}
 
 				// Reassign the lock payment order to another provider

--- a/services/priority_queue.go
+++ b/services/priority_queue.go
@@ -141,7 +141,7 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 	err := s.deleteQueue(ctx, prevRedisKey)
 	if err != nil && err != context.Canceled {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Key": prevRedisKey,
 		}).Errorf("failed to delete previous provider queue")
 	}
@@ -150,7 +150,7 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 	prevData, err := storage.RedisClient.LRange(ctx, redisKey, 0, -1).Result()
 	if err != nil && err != context.Canceled {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Key": redisKey,
 		}).Errorf("failed to fetch provider rates")
 	}
@@ -166,7 +166,7 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 		err = storage.RedisClient.RPush(ctx, prevRedisKey, prevValues...).Err()
 		if err != nil && err != context.Canceled {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"Key": prevRedisKey,
 				"Values": prevValues,
 			}).Errorf("failed to store previous provider rates")
@@ -177,7 +177,7 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 	err = s.deleteQueue(ctx, redisKey)
 	if err != nil && err != context.Canceled {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Key": redisKey,
 		}).Errorf("failed to delete existing circular queue")
 	}
@@ -202,7 +202,7 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 		if err != nil {
 			if err != context.Canceled {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"ProviderID": provider.ID,
 					"Currency": bucket.Edges.Currency.Code,
 				}).Errorf("failed to get tokens for provider")
@@ -221,7 +221,7 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 			if err != nil {
 				if err != context.Canceled {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"ProviderID": provider.ID,
 						"Token": orderToken.Edges.Token.Symbol,
 						"Currency": bucket.Edges.Currency.Code,
@@ -251,7 +251,7 @@ func (s *PriorityQueueService) CreatePriorityQueueForBucket(ctx context.Context,
 			err = storage.RedisClient.RPush(ctx, redisKey, data).Err()
 			if err != nil && err != context.Canceled {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"Key": redisKey,
 					"Data": data,
 				}).Errorf("failed to enqueue provider data to circular queue")
@@ -267,7 +267,7 @@ func (s *PriorityQueueService) AssignLockPaymentOrder(ctx context.Context, order
 	excludeList, err := storage.RedisClient.LRange(ctx, fmt.Sprintf("order_exclude_list_%s", order.ID), 0, -1).Result()
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"OrderID": order.ID,
 			"ProviderID": order.ProviderID,
 		}).Errorf("failed to get exclude list")
@@ -291,7 +291,7 @@ func (s *PriorityQueueService) AssignLockPaymentOrder(ctx context.Context, order
 				order.Rate, err = s.GetProviderRate(ctx, provider, order.Token.Symbol, order.ProvisionBucket.Edges.Currency.Code)
 				if err != nil {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"OrderID": order.ID,
 						"ProviderID": order.ProviderID,
 					}).Errorf("failed to get rate for provider")
@@ -303,7 +303,7 @@ func (s *PriorityQueueService) AssignLockPaymentOrder(ctx context.Context, order
 					Save(ctx)
 				if err != nil {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"OrderID": order.ID,
 						"ProviderID": order.ProviderID,
 					}).Errorf("failed to update rate for provider")
@@ -314,13 +314,13 @@ func (s *PriorityQueueService) AssignLockPaymentOrder(ctx context.Context, order
 				return nil
 			}
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": order.ID,
 				"ProviderID": order.ProviderID,
 			}).Errorf("failed to send order request to specific provider")
 		} else {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": order.ID,
 				"ProviderID": order.ProviderID,
 			}).Errorf("failed to get provider")
@@ -340,7 +340,7 @@ func (s *PriorityQueueService) AssignLockPaymentOrder(ctx context.Context, order
 	if err != nil {
 		prevRedisKey := redisKey + "_prev"
 		err = s.matchRate(ctx, prevRedisKey, orderIDPrefix, order, excludeList)
-		if err != nil && !strings.Contains(err.Error(), "redis: nil") {
+		if err != nil && !strings.Contains(fmt.Sprintf("%v", err), "redis: nil") {
 			return err
 		}
 	}
@@ -362,7 +362,7 @@ func (s *PriorityQueueService) sendOrderRequest(ctx context.Context, order types
 
 	if err := storage.RedisClient.HSet(ctx, orderKey, orderRequestData).Err(); err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"OrderID": order.ID,
 			"ProviderID": order.ProviderID,
 			"orderKey": orderKey,
@@ -375,7 +375,7 @@ func (s *PriorityQueueService) sendOrderRequest(ctx context.Context, order types
 	if err != nil {
 		// logger.Errorf("failed to set TTL for order request: %v", err)
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"orderKey": orderKey,
 		}).Errorf("failed to set TTL for order request")
 		return err
@@ -385,7 +385,7 @@ func (s *PriorityQueueService) sendOrderRequest(ctx context.Context, order types
 	orderRequestData["orderId"] = order.ID
 	if err := s.notifyProvider(ctx, orderRequestData); err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"OrderID": order.ID,
 			"ProviderID": order.ProviderID,
 		}).Errorf("failed to notify provider")
@@ -437,7 +437,7 @@ func (s *PriorityQueueService) notifyProvider(ctx context.Context, orderRequestD
 	data, err := utils.ParseJSONResponse(res.RawResponse)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"ProviderID": providerID,
 		}).Errorf("failed to parse JSON response after new order request with data: %v", data)
 		return err
@@ -472,7 +472,7 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 		parts := strings.Split(providerData, ":")
 		if len(parts) != 5 {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": order.ID,
 				"ProviderID": order.ProviderID,
 				"ProviderData": providerData,
@@ -551,7 +551,7 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 				data, err := storage.RedisClient.LPop(ctx, redisKey).Result()
 				if err != nil {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"OrderID": order.ID,
 						"ProviderID": order.ProviderID,
 						"redisKey": redisKey,
@@ -564,7 +564,7 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 				err = storage.RedisClient.RPush(ctx, redisKey, data).Err()
 				if err != nil {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"OrderID": order.ID,
 						"ProviderID": order.ProviderID,
 						"redisKey": redisKey,
@@ -578,7 +578,7 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 			err = s.sendOrderRequest(ctx, order)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"OrderID": order.ID,
 					"ProviderID": order.ProviderID,
 					"redisKey": redisKey,
@@ -590,7 +590,7 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 				_, err = storage.RedisClient.RPush(ctx, orderKey, order.ProviderID).Result()
 				if err != nil {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"OrderID": order.ID,
 						"ProviderID": order.ProviderID,
 						"redisKey": redisKey,

--- a/services/priority_queue.go
+++ b/services/priority_queue.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -268,7 +269,7 @@ func (s *PriorityQueueService) AssignLockPaymentOrder(ctx context.Context, order
 	if err != nil {
 		logger.WithFields(logger.Fields{
 			"Error": fmt.Sprintf("%v", err),
-			"OrderID": order.ID,
+			"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 			"ProviderID": order.ProviderID,
 		}).Errorf("failed to get exclude list")
 		return err
@@ -292,7 +293,7 @@ func (s *PriorityQueueService) AssignLockPaymentOrder(ctx context.Context, order
 				if err != nil {
 					logger.WithFields(logger.Fields{
 						"Error": fmt.Sprintf("%v", err),
-						"OrderID": order.ID,
+						"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 						"ProviderID": order.ProviderID,
 					}).Errorf("failed to get rate for provider")
 				}
@@ -304,7 +305,7 @@ func (s *PriorityQueueService) AssignLockPaymentOrder(ctx context.Context, order
 				if err != nil {
 					logger.WithFields(logger.Fields{
 						"Error": fmt.Sprintf("%v", err),
-						"OrderID": order.ID,
+						"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 						"ProviderID": order.ProviderID,
 					}).Errorf("failed to update rate for provider")
 				}
@@ -315,13 +316,13 @@ func (s *PriorityQueueService) AssignLockPaymentOrder(ctx context.Context, order
 			}
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
-				"OrderID": order.ID,
+				"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 				"ProviderID": order.ProviderID,
 			}).Errorf("failed to send order request to specific provider")
 		} else {
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
-				"OrderID": order.ID,
+				"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 				"ProviderID": order.ProviderID,
 			}).Errorf("failed to get provider")
 		}
@@ -363,7 +364,7 @@ func (s *PriorityQueueService) sendOrderRequest(ctx context.Context, order types
 	if err := storage.RedisClient.HSet(ctx, orderKey, orderRequestData).Err(); err != nil {
 		logger.WithFields(logger.Fields{
 			"Error": fmt.Sprintf("%v", err),
-			"OrderID": order.ID,
+			"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 			"ProviderID": order.ProviderID,
 			"orderKey": orderKey,
 		}).Errorf("failed to map order to a provider in Redis")
@@ -386,7 +387,7 @@ func (s *PriorityQueueService) sendOrderRequest(ctx context.Context, order types
 	if err := s.notifyProvider(ctx, orderRequestData); err != nil {
 		logger.WithFields(logger.Fields{
 			"Error": fmt.Sprintf("%v", err),
-			"OrderID": order.ID,
+			"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 			"ProviderID": order.ProviderID,
 		}).Errorf("failed to notify provider")
 		return err
@@ -473,7 +474,7 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 		if len(parts) != 5 {
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
-				"OrderID": order.ID,
+				"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 				"ProviderID": order.ProviderID,
 				"ProviderData": providerData,
 			}).Errorf("invalid data format at index %d when matching rate", index)
@@ -552,7 +553,7 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 				if err != nil {
 					logger.WithFields(logger.Fields{
 						"Error": fmt.Sprintf("%v", err),
-						"OrderID": order.ID,
+						"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 						"ProviderID": order.ProviderID,
 						"redisKey": redisKey,
 						"orderIDPrefix": orderIDPrefix,
@@ -565,7 +566,7 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 				if err != nil {
 					logger.WithFields(logger.Fields{
 						"Error": fmt.Sprintf("%v", err),
-						"OrderID": order.ID,
+						"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 						"ProviderID": order.ProviderID,
 						"redisKey": redisKey,
 						"orderIDPrefix": orderIDPrefix,
@@ -579,7 +580,7 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 			if err != nil {
 				logger.WithFields(logger.Fields{
 					"Error": fmt.Sprintf("%v", err),
-					"OrderID": order.ID,
+					"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 					"ProviderID": order.ProviderID,
 					"redisKey": redisKey,
 					"orderIDPrefix": orderIDPrefix,
@@ -591,7 +592,7 @@ func (s *PriorityQueueService) matchRate(ctx context.Context, redisKey string, o
 				if err != nil {
 					logger.WithFields(logger.Fields{
 						"Error": fmt.Sprintf("%v", err),
-						"OrderID": order.ID,
+						"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 						"ProviderID": order.ProviderID,
 						"redisKey": redisKey,
 						"orderIDPrefix": orderIDPrefix,

--- a/services/priority_queue_test.go
+++ b/services/priority_queue_test.go
@@ -339,6 +339,18 @@ func TestPriorityQueueTest(t *testing.T) {
 
 		assert.NoError(t, err)
 
+		// Setup httpmock for sendOrderRequest
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("POST", testCtxForPQ.publicProviderProfile.HostIdentifier+"/new_order",
+			func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewJsonResponse(200, map[string]interface{}{
+					"status": "success",
+					"message": "Order processed successfully",
+				})
+		})
+
 		err = service.sendOrderRequest(context.Background(), types.LockPaymentOrderFields{
 			ID:                order.ID,
 			ProviderID:        testCtxForPQ.publicProviderProfile.ID,

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"context"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"strings"
@@ -140,7 +141,7 @@ func RetryStaleUserOperations() error {
 				if err != nil {
 					logger.WithFields(logger.Fields{
 						"Error": fmt.Sprintf("%v", err),
-						"OrderID": order.ID,
+						"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 						"AmountPaid": order.AmountPaid,
 						"Amount": order.Amount,
 						"PercentSettled": order.PercentSettled,
@@ -184,7 +185,7 @@ func RetryStaleUserOperations() error {
 			if err != nil {
 				logger.WithFields(logger.Fields{
 					"Error": fmt.Sprintf("%v", err),
-					"OrderID": order.ID,
+					"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 					"Amount": order.Amount,
 					"GatewayID": order.GatewayID,
 					"NetworkIdentifier": order.Edges.Token.Edges.Network.Identifier,
@@ -249,7 +250,7 @@ func RetryStaleUserOperations() error {
 			if err != nil {
 				logger.WithFields(logger.Fields{
 					"Error": fmt.Sprintf("%v", err),
-					"OrderID": order.ID,
+					"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 					"Amount": order.Amount,
 					"GatewayID": order.GatewayID,
 					"NetworkIdentifier": order.Edges.Token.Edges.Network.Identifier,
@@ -282,7 +283,7 @@ func RetryStaleUserOperations() error {
 			if err != nil {
 				logger.WithFields(logger.Fields{
 					"Error": fmt.Sprintf("%v", err),
-					"OrderID": order.ID,
+					"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 					"Amount": order.Amount,
 					"GatewayID": order.GatewayID,
 					"NetworkIdentifier": order.Edges.Token.Edges.Network.Identifier,
@@ -628,7 +629,7 @@ func ReassignPendingOrders() {
 		if err != nil {
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
-				"OrderID": order.ID,
+				"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 				"OrderKey": orderKey,
 				"Reason": "redis: No pending orders found",
 			}).Errorf("Redis: Failed to reassign pending orders")
@@ -659,7 +660,7 @@ func ReassignPendingOrders() {
 			if err != nil {
 				logger.WithFields(logger.Fields{
 					"Error": fmt.Sprintf("%v", err),
-					"OrderID": order.ID,
+					"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 					"OrderKey": orderKey,
 					"GatewayID": order.GatewayID,
 				}).Errorf("Redis: Failed to reassign declined order request")
@@ -738,7 +739,7 @@ func SyncLockOrderFulfillments() {
 			if err != nil {
 				logger.WithFields(logger.Fields{
 					"Error": fmt.Sprintf("%v", err),
-					"OrderID": order.ID,
+					"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 					"ProviderID": order.Edges.Provider.ID,
 					"Reason": "internal: Failed to decode provider secret",
 				}).Errorf("SyncLockOrderFulfillments.DecodeSecret")
@@ -748,7 +749,7 @@ func SyncLockOrderFulfillments() {
 			if err != nil {
 				logger.WithFields(logger.Fields{
 					"Error": fmt.Sprintf("%v", err),
-					"OrderID": order.ID,
+					"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 					"ProviderID": order.Edges.Provider.ID,
 					"Reason": "internal: Failed to decrypt provider secret",
 				}).Errorf("SyncLockOrderFulfillments.DecryptSecret")
@@ -756,7 +757,7 @@ func SyncLockOrderFulfillments() {
 			}
 
 			payload := map[string]interface{}{
-				"orderId":  order.ID.String(),
+				"orderId":  fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 				"currency": order.Edges.ProvisionBucket.Edges.Currency.Code,
 			}
 			signature := tokenUtils.GenerateHMACSignature(payload, string(decryptedSecret))
@@ -771,7 +772,7 @@ func SyncLockOrderFulfillments() {
 			if err != nil {
 				logger.WithFields(logger.Fields{
 					"Error": fmt.Sprintf("%v", err),
-					"OrderID": order.ID,
+					"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 					"ProviderID": order.Edges.Provider.ID,
 					"PayloadOrderId": payload["orderId"],
 					"PayloadCurrency": payload["currency"],
@@ -787,7 +788,7 @@ func SyncLockOrderFulfillments() {
 					if updateErr != nil {
 						logger.WithFields(logger.Fields{
 							"Error": updateErr,
-							"OrderID": order.ID,
+							"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 							"ProviderID": order.Edges.Provider.ID,
 							"Reason": "internal: Failed to update order status",
 						}).Errorf("SyncLockOrderFulfillments.UpdateStatus")
@@ -801,7 +802,7 @@ func SyncLockOrderFulfillments() {
 				if order.Status == lockpaymentorder.StatusProcessing && order.UpdatedAt.Add(orderConf.OrderFulfillmentValidity*2).Before(time.Now()) {
 					logger.WithFields(logger.Fields{
 						"Error": fmt.Sprintf("%v", err),
-						"OrderID": order.ID,
+						"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 						"ProviderID": order.Edges.Provider.ID,
 						"PayloadOrderId": payload["orderId"],
 						"PayloadCurrency": payload["currency"],
@@ -813,7 +814,7 @@ func SyncLockOrderFulfillments() {
 					if err != nil {
 						logger.WithFields(logger.Fields{
 							"Error": fmt.Sprintf("%v", err),
-							"OrderID": order.ID,
+							"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 							"ProviderID": order.Edges.Provider.ID,
 						}).Errorf("Failed to delete order after failing to parse JSON response when getting trx status from provider")
 					}
@@ -888,7 +889,7 @@ func SyncLockOrderFulfillments() {
 					if err != nil {
 						logger.WithFields(logger.Fields{
 							"Error": fmt.Sprintf("%v", err),
-							"OrderID": order.ID,
+							"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 							"ProviderID": order.Edges.Provider.ID,
 						}).Errorf("Failed to decode provider secret for pending fulfillment")
 						continue
@@ -897,14 +898,14 @@ func SyncLockOrderFulfillments() {
 					if err != nil {
 						logger.WithFields(logger.Fields{
 							"Error": fmt.Sprintf("%v", err),
-							"OrderID": order.ID,
+							"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 							"ProviderID": order.Edges.Provider.ID,
 						}).Errorf("Failed to decrypt provider secret for pending fulfillment")
 						continue
 					}
 
 					payload := map[string]interface{}{
-						"orderId":  order.ID.String(),
+						"orderId":  fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 						"currency": order.Edges.ProvisionBucket.Edges.Currency.Code,
 						"psp":      fulfillment.Psp,
 						"txId":     fulfillment.TxID,
@@ -927,7 +928,7 @@ func SyncLockOrderFulfillments() {
 					if err != nil {
 						logger.WithFields(logger.Fields{
 							"Error": fmt.Sprintf("%v", err),
-							"OrderID": order.ID,
+							"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 							"ProviderID": order.Edges.Provider.ID,
 							"PayloadOrderId": payload["orderId"],
 							"PayloadCurrency": payload["currency"],
@@ -1035,7 +1036,7 @@ func SyncLockOrderFulfillments() {
 						if err != nil {
 							logger.WithFields(logger.Fields{
 								"Error": fmt.Sprintf("%v", err),
-								"OrderID": order.ID,
+								"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 								"OrderKey": orderKey,
 								"GatewayID": order.GatewayID,
 							}).Errorf("Redis: Failed to reassign declined order request")
@@ -1095,7 +1096,7 @@ func ReassignStaleOrderRequest(ctx context.Context, orderRequestChan <-chan *red
 		if err != nil {
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
-				"OrderID": orderID,
+				"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 				"UUID": orderUUID,
 			}).Errorf("ReassignStaleOrderRequest: Failed to get order from database")
 			continue
@@ -1120,7 +1121,7 @@ func ReassignStaleOrderRequest(ctx context.Context, orderRequestChan <-chan *red
 			// logger.Errorf("ReassignStaleOrderRequest.AssignLockPaymentOrder: %v", err)
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
-				"OrderID": orderID,
+				"OrderID": fmt.Sprintf("0x%v", hex.EncodeToString(order.ID[:])),
 				"UUID": orderUUID,
 				"GatewayID": order.GatewayID,
 			}).Errorf("ReassignStaleOrderRequest: Failed to assign order to provider")

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -70,7 +70,7 @@ func setRPCClients(ctx context.Context) ([]*ent.Network, error) {
 			})
 			if retryErr != nil {
 				logger.WithFields(logger.Fields{
-					"Error": retryErr,
+					"Error": fmt.Sprintf("%v", err),
 					"Network": network.Identifier,
 				}).Errorf("failed to connect to RPC client")
 				continue
@@ -139,7 +139,7 @@ func RetryStaleUserOperations() error {
 				err := service.CreateOrder(ctx, rpcClients[order.Edges.Token.Edges.Network.Identifier], order.ID)
 				if err != nil {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"OrderID": order.ID,
 						"AmountPaid": order.AmountPaid,
 						"Amount": order.Amount,
@@ -183,7 +183,7 @@ func RetryStaleUserOperations() error {
 			err := service.SettleOrder(ctx, rpcClients[order.Edges.Token.Edges.Network.Identifier], order.ID)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"OrderID": order.ID,
 					"Amount": order.Amount,
 					"GatewayID": order.GatewayID,
@@ -248,7 +248,7 @@ func RetryStaleUserOperations() error {
 			err := service.RefundOrder(ctx, rpcClients[order.Edges.Token.Edges.Network.Identifier], order.Edges.Token.Edges.Network, order.GatewayID)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"OrderID": order.ID,
 					"Amount": order.Amount,
 					"GatewayID": order.GatewayID,
@@ -281,7 +281,7 @@ func RetryStaleUserOperations() error {
 			err = service.CreateOrder(ctx, rpcClients[order.Edges.Token.Edges.Network.Identifier], order.ID)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"OrderID": order.ID,
 					"Amount": order.Amount,
 					"GatewayID": order.GatewayID,
@@ -331,7 +331,7 @@ func IndexBlockchainEvents() error {
 			All(ctx)
 		if err != nil && err != context.Canceled {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"Status": paymentorder.StatusInitiated,
 			}).Errorf("Failed to index blockchain events for unused receive addresses")
 		}
@@ -441,7 +441,7 @@ func IndexBlockchainEvents() error {
 					All(ctx)
 				if err != nil && err != context.Canceled {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"Status": lockpaymentorder.StatusValidated,
 						"Network": network.Identifier,
 						"NetworkID": network.ID,
@@ -501,7 +501,7 @@ func IndexBlockchainEvents() error {
 					All(ctx)
 				if err != nil && err != context.Canceled {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"Status": lockpaymentorder.StatusPending,
 						"Network": network.Identifier,
 						"NetworkID": network.ID,
@@ -554,7 +554,7 @@ func IndexLinkedAddresses() error {
 			All(ctx)
 		if err != nil && err != context.Canceled {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"Status": tokenent.IsEnabled(true),
 				"Reason": "db:No tokens found",
 			}).Errorf("Failed to index blockchain events for linked addresses")
@@ -590,7 +590,7 @@ func ReassignPendingOrders() {
 		Save(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Status": lockpaymentorder.StatusPending,
 			"Reason": "db: No pending orders found",
 		}).Errorf("Failed to reassign pending orders")
@@ -614,7 +614,7 @@ func ReassignPendingOrders() {
 		All(ctx)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"Error": err,
+			"Error": fmt.Sprintf("%v", err),
 			"Status": lockpaymentorder.StatusPending,
 			"Reason": "db: No pending orders found",
 		}).Errorf("Failed to reassign pending orders")
@@ -627,7 +627,7 @@ func ReassignPendingOrders() {
 		exists, err := storage.RedisClient.Exists(ctx, orderKey).Result()
 		if err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": order.ID,
 				"OrderKey": orderKey,
 				"Reason": "redis: No pending orders found",
@@ -658,7 +658,7 @@ func ReassignPendingOrders() {
 			err := services.NewPriorityQueueService().AssignLockPaymentOrder(ctx, lockPaymentOrder)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"OrderID": order.ID,
 					"OrderKey": orderKey,
 					"GatewayID": order.GatewayID,
@@ -737,7 +737,7 @@ func SyncLockOrderFulfillments() {
 			decodedSecret, err := base64.StdEncoding.DecodeString(order.Edges.Provider.Edges.APIKey.Secret)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"OrderID": order.ID,
 					"ProviderID": order.Edges.Provider.ID,
 					"Reason": "internal: Failed to decode provider secret",
@@ -747,7 +747,7 @@ func SyncLockOrderFulfillments() {
 			decryptedSecret, err := cryptoUtils.DecryptPlain(decodedSecret)
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"OrderID": order.ID,
 					"ProviderID": order.Edges.Provider.ID,
 					"Reason": "internal: Failed to decrypt provider secret",
@@ -770,7 +770,7 @@ func SyncLockOrderFulfillments() {
 				Send()
 			if err != nil {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"OrderID": order.ID,
 					"ProviderID": order.Edges.Provider.ID,
 					"PayloadOrderId": payload["orderId"],
@@ -779,7 +779,7 @@ func SyncLockOrderFulfillments() {
 				}).Errorf("SyncLockOrderFulfillments.SendRequest")
 
 				// Set status to pending on 400 error
-				if strings.Contains(err.Error(), "400") {
+				if strings.Contains(fmt.Sprintf("%v", err), "400") {
 					_, updateErr := storage.Client.LockPaymentOrder.
 						UpdateOneID(order.ID).
 						SetStatus(lockpaymentorder.StatusPending).
@@ -800,7 +800,7 @@ func SyncLockOrderFulfillments() {
 			if err != nil {
 				if order.Status == lockpaymentorder.StatusProcessing && order.UpdatedAt.Add(orderConf.OrderFulfillmentValidity*2).Before(time.Now()) {
 					logger.WithFields(logger.Fields{
-						"Error": err,
+						"Error": fmt.Sprintf("%v", err),
 						"OrderID": order.ID,
 						"ProviderID": order.Edges.Provider.ID,
 						"PayloadOrderId": payload["orderId"],
@@ -812,7 +812,7 @@ func SyncLockOrderFulfillments() {
 						Exec(ctx)
 					if err != nil {
 						logger.WithFields(logger.Fields{
-							"Error": err,
+							"Error": fmt.Sprintf("%v", err),
 							"OrderID": order.ID,
 							"ProviderID": order.Edges.Provider.ID,
 						}).Errorf("Failed to delete order after failing to parse JSON response when getting trx status from provider")
@@ -887,7 +887,7 @@ func SyncLockOrderFulfillments() {
 					decodedSecret, err := base64.StdEncoding.DecodeString(order.Edges.Provider.Edges.APIKey.Secret)
 					if err != nil {
 						logger.WithFields(logger.Fields{
-							"Error": err,
+							"Error": fmt.Sprintf("%v", err),
 							"OrderID": order.ID,
 							"ProviderID": order.Edges.Provider.ID,
 						}).Errorf("Failed to decode provider secret for pending fulfillment")
@@ -896,7 +896,7 @@ func SyncLockOrderFulfillments() {
 					decryptedSecret, err := cryptoUtils.DecryptPlain(decodedSecret)
 					if err != nil {
 						logger.WithFields(logger.Fields{
-							"Error": err,
+							"Error": fmt.Sprintf("%v", err),
 							"OrderID": order.ID,
 							"ProviderID": order.Edges.Provider.ID,
 						}).Errorf("Failed to decrypt provider secret for pending fulfillment")
@@ -926,7 +926,7 @@ func SyncLockOrderFulfillments() {
 					data, err := utils.ParseJSONResponse(res.RawResponse)
 					if err != nil {
 						logger.WithFields(logger.Fields{
-							"Error": err,
+							"Error": fmt.Sprintf("%v", err),
 							"OrderID": order.ID,
 							"ProviderID": order.Edges.Provider.ID,
 							"PayloadOrderId": payload["orderId"],
@@ -1034,7 +1034,7 @@ func SyncLockOrderFulfillments() {
 						err = services.NewPriorityQueueService().AssignLockPaymentOrder(ctx, lockPaymentOrder)
 						if err != nil {
 							logger.WithFields(logger.Fields{
-								"Error": err,
+								"Error": fmt.Sprintf("%v", err),
 								"OrderID": order.ID,
 								"OrderKey": orderKey,
 								"GatewayID": order.GatewayID,
@@ -1078,7 +1078,7 @@ func ReassignStaleOrderRequest(ctx context.Context, orderRequestChan <-chan *red
 		orderUUID, err := uuid.Parse(orderID)
 		if err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": orderID,
 			}).Errorf("ReassignStaleOrderRequest: Failed to parse order ID")
 			continue
@@ -1094,7 +1094,7 @@ func ReassignStaleOrderRequest(ctx context.Context, orderRequestChan <-chan *red
 			Only(ctx)
 		if err != nil {
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": orderID,
 				"UUID": orderUUID,
 			}).Errorf("ReassignStaleOrderRequest: Failed to get order from database")
@@ -1119,7 +1119,7 @@ func ReassignStaleOrderRequest(ctx context.Context, orderRequestChan <-chan *red
 		if err != nil {
 			// logger.Errorf("ReassignStaleOrderRequest.AssignLockPaymentOrder: %v", err)
 			logger.WithFields(logger.Fields{
-				"Error": err,
+				"Error": fmt.Sprintf("%v", err),
 				"OrderID": orderID,
 				"UUID": orderUUID,
 				"GatewayID": order.GatewayID,

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -69,7 +69,10 @@ func setRPCClients(ctx context.Context) ([]*ent.Network, error) {
 				return err
 			})
 			if retryErr != nil {
-				logger.Errorf("failed to connect to %s RPC %v", network.Identifier, retryErr)
+				logger.WithFields(logger.Fields{
+					"Error": retryErr,
+					"Network": network.Identifier,
+				}).Errorf("failed to connect to RPC client")
 				continue
 			}
 
@@ -135,7 +138,15 @@ func RetryStaleUserOperations() error {
 				}
 				err := service.CreateOrder(ctx, rpcClients[order.Edges.Token.Edges.Network.Identifier], order.ID)
 				if err != nil {
-					logger.Errorf("RetryStaleUserOperations.CreateOrder %v", err)
+					logger.WithFields(logger.Fields{
+						"Error": err,
+						"OrderID": order.ID,
+						"AmountPaid": order.AmountPaid,
+						"Amount": order.Amount,
+						"PercentSettled": order.PercentSettled,
+						"GatewayID": order.GatewayID,
+						"NetworkIdentifier": order.Edges.Token.Edges.Network.Identifier,
+					}).Errorf("RetryStaleUserOperations.CreateOrder")
 				}
 			}
 		}
@@ -171,7 +182,13 @@ func RetryStaleUserOperations() error {
 			}
 			err := service.SettleOrder(ctx, rpcClients[order.Edges.Token.Edges.Network.Identifier], order.ID)
 			if err != nil {
-				logger.Errorf("RetryStaleUserOperations.SettleOrder: %v", err)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"OrderID": order.ID,
+					"Amount": order.Amount,
+					"GatewayID": order.GatewayID,
+					"NetworkIdentifier": order.Edges.Token.Edges.Network.Identifier,
+				}).Errorf("RetryStaleUserOperations.SettleOrder")
 			}
 		}
 	}(ctx)
@@ -230,7 +247,13 @@ func RetryStaleUserOperations() error {
 			}
 			err := service.RefundOrder(ctx, rpcClients[order.Edges.Token.Edges.Network.Identifier], order.Edges.Token.Edges.Network, order.GatewayID)
 			if err != nil {
-				logger.Errorf("RetryStaleUserOperations.RefundOrder: %v", err)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"OrderID": order.ID,
+					"Amount": order.Amount,
+					"GatewayID": order.GatewayID,
+					"NetworkIdentifier": order.Edges.Token.Edges.Network.Identifier,
+				}).Errorf("RetryStaleUserOperations.RefundOrder")
 			}
 		}
 	}(ctx)
@@ -257,7 +280,13 @@ func RetryStaleUserOperations() error {
 			service := orderService.NewOrderEVM()
 			err = service.CreateOrder(ctx, rpcClients[order.Edges.Token.Edges.Network.Identifier], order.ID)
 			if err != nil {
-				logger.Errorf("RetryStaleUserOperations.RetryLinkedAddress: %v", err)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"OrderID": order.ID,
+					"Amount": order.Amount,
+					"GatewayID": order.GatewayID,
+					"NetworkIdentifier": order.Edges.Token.Edges.Network.Identifier,
+				}).Errorf("RetryStaleUserOperations.RetryLinkedAddress")
 			}
 		}
 	}(ctx)
@@ -301,7 +330,10 @@ func IndexBlockchainEvents() error {
 			WithRecipient().
 			All(ctx)
 		if err != nil && err != context.Canceled {
-			logger.Errorf("IndexBlockchainEvents: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"Status": paymentorder.StatusInitiated,
+			}).Errorf("Failed to index blockchain events for unused receive addresses")
 		}
 
 		for _, order := range orders {
@@ -408,7 +440,13 @@ func IndexBlockchainEvents() error {
 					Order(ent.Asc(lockpaymentorder.FieldBlockNumber)).
 					All(ctx)
 				if err != nil && err != context.Canceled {
-					logger.Errorf("IndexBlockchainEvents: %v", err)
+					logger.WithFields(logger.Fields{
+						"Error": err,
+						"Status": lockpaymentorder.StatusValidated,
+						"Network": network.Identifier,
+						"NetworkID": network.ID,
+						"FieldGatewayID": lockpaymentorder.FieldGatewayID,
+					}).Errorf("Failed to index blockchain events for unused receive addresses")
 				}
 
 				for _, order := range lockOrders {
@@ -462,7 +500,13 @@ func IndexBlockchainEvents() error {
 					Order(ent.Asc(lockpaymentorder.FieldBlockNumber)).
 					All(ctx)
 				if err != nil && err != context.Canceled {
-					logger.Errorf("IndexBlockchainEvents: %v", err)
+					logger.WithFields(logger.Fields{
+						"Error": err,
+						"Status": lockpaymentorder.StatusPending,
+						"Network": network.Identifier,
+						"NetworkID": network.ID,
+						"FieldGatewayID": lockpaymentorder.FieldGatewayID,
+					}).Errorf("Failed to index blockchain events for unused receive addresses")
 				}
 
 				if len(lockOrders) > 0 {
@@ -509,7 +553,12 @@ func IndexLinkedAddresses() error {
 			WithNetwork().
 			All(ctx)
 		if err != nil && err != context.Canceled {
-			logger.Errorf("IndexLinkedAddresses: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"Status": tokenent.IsEnabled(true),
+				"Reason": "db:No tokens found",
+			}).Errorf("Failed to index blockchain events for linked addresses")
+			return
 		}
 
 		for _, token := range tokens {
@@ -540,7 +589,11 @@ func ReassignPendingOrders() {
 		ClearProvider().
 		Save(ctx)
 	if err != nil {
-		logger.Errorf("ReassignPendingOrders.db: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"Status": lockpaymentorder.StatusPending,
+			"Reason": "db: No pending orders found",
+		}).Errorf("Failed to reassign pending orders")
 		return
 	}
 
@@ -560,7 +613,11 @@ func ReassignPendingOrders() {
 		).
 		All(ctx)
 	if err != nil {
-		logger.Errorf("ReassignPendingOrders.db: %v", err)
+		logger.WithFields(logger.Fields{
+			"Error": err,
+			"Status": lockpaymentorder.StatusPending,
+			"Reason": "db: No pending orders found",
+		}).Errorf("Failed to reassign pending orders")
 		return
 	}
 
@@ -569,7 +626,12 @@ func ReassignPendingOrders() {
 		orderKey := fmt.Sprintf("order_request_%s", order.ID)
 		exists, err := storage.RedisClient.Exists(ctx, orderKey).Result()
 		if err != nil {
-			logger.Errorf("ReassignPendingOrders.redis: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"OrderID": order.ID,
+				"OrderKey": orderKey,
+				"Reason": "redis: No pending orders found",
+			}).Errorf("Redis: Failed to reassign pending orders")
 			continue
 		}
 
@@ -595,7 +657,12 @@ func ReassignPendingOrders() {
 
 			err := services.NewPriorityQueueService().AssignLockPaymentOrder(ctx, lockPaymentOrder)
 			if err != nil {
-				logger.Errorf("failed to reassign declined order request: %v", err)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"OrderID": order.ID,
+					"OrderKey": orderKey,
+					"GatewayID": order.GatewayID,
+				}).Errorf("Redis: Failed to reassign declined order request")
 			}
 		}
 	}
@@ -669,12 +736,22 @@ func SyncLockOrderFulfillments() {
 			// Compute HMAC
 			decodedSecret, err := base64.StdEncoding.DecodeString(order.Edges.Provider.Edges.APIKey.Secret)
 			if err != nil {
-				logger.Errorf("SyncLockOrderFulfillments.DecodeSecret: %v %v", err, order.Edges.Provider.ID)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"OrderID": order.ID,
+					"ProviderID": order.Edges.Provider.ID,
+					"Reason": "internal: Failed to decode provider secret",
+				}).Errorf("SyncLockOrderFulfillments.DecodeSecret")
 				continue
 			}
 			decryptedSecret, err := cryptoUtils.DecryptPlain(decodedSecret)
 			if err != nil {
-				logger.Errorf("SyncLockOrderFulfillments.DecryptSecret: %v %v", err, order.Edges.Provider.ID)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"OrderID": order.ID,
+					"ProviderID": order.Edges.Provider.ID,
+					"Reason": "internal: Failed to decrypt provider secret",
+				}).Errorf("SyncLockOrderFulfillments.DecryptSecret")
 				continue
 			}
 
@@ -692,7 +769,14 @@ func SyncLockOrderFulfillments() {
 				Body().AsJSON(payload).
 				Send()
 			if err != nil {
-				logger.Errorf("SyncLockOrderFulfillments: %v %v", err, payload)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"OrderID": order.ID,
+					"ProviderID": order.Edges.Provider.ID,
+					"PayloadOrderId": payload["orderId"],
+					"PayloadCurrency": payload["currency"],
+					"Reason": "internal: Failed to send tx_status request to provider",
+				}).Errorf("SyncLockOrderFulfillments.SendRequest")
 
 				// Set status to pending on 400 error
 				if strings.Contains(err.Error(), "400") {
@@ -701,7 +785,12 @@ func SyncLockOrderFulfillments() {
 						SetStatus(lockpaymentorder.StatusPending).
 						Save(ctx)
 					if updateErr != nil {
-						logger.Errorf("SyncLockOrderFulfillments.UpdateStatus: %v", updateErr)
+						logger.WithFields(logger.Fields{
+							"Error": updateErr,
+							"OrderID": order.ID,
+							"ProviderID": order.Edges.Provider.ID,
+							"Reason": "internal: Failed to update order status",
+						}).Errorf("SyncLockOrderFulfillments.UpdateStatus")
 					}
 				}
 				continue
@@ -710,13 +799,23 @@ func SyncLockOrderFulfillments() {
 			data, err := utils.ParseJSONResponse(res.RawResponse)
 			if err != nil {
 				if order.Status == lockpaymentorder.StatusProcessing && order.UpdatedAt.Add(orderConf.OrderFulfillmentValidity*2).Before(time.Now()) {
-					logger.Errorf("SyncLockOrderFulfillments.StuckProcessing: %v %v", err, payload)
+					logger.WithFields(logger.Fields{
+						"Error": err,
+						"OrderID": order.ID,
+						"ProviderID": order.Edges.Provider.ID,
+						"PayloadOrderId": payload["orderId"],
+						"PayloadCurrency": payload["currency"],
+					}).Errorf("Failed to parse JSON response after getting trx status from provider")
 					// delete lock order to trigger re-indexing
 					err := storage.Client.LockPaymentOrder.
 						DeleteOneID(order.ID).
 						Exec(ctx)
 					if err != nil {
-						logger.Errorf("SyncLockOrderFulfillments.DeleteOrder: %v", err)
+						logger.WithFields(logger.Fields{
+							"Error": err,
+							"OrderID": order.ID,
+							"ProviderID": order.Edges.Provider.ID,
+						}).Errorf("Failed to delete order after failing to parse JSON response when getting trx status from provider")
 					}
 					continue
 				}
@@ -787,12 +886,20 @@ func SyncLockOrderFulfillments() {
 					// Compute HMAC
 					decodedSecret, err := base64.StdEncoding.DecodeString(order.Edges.Provider.Edges.APIKey.Secret)
 					if err != nil {
-						logger.Errorf("SyncLockOrderFulfillments.DecodeSecret: %v %v", err, order.Edges.Provider.ID)
+						logger.WithFields(logger.Fields{
+							"Error": err,
+							"OrderID": order.ID,
+							"ProviderID": order.Edges.Provider.ID,
+						}).Errorf("Failed to decode provider secret for pending fulfillment")
 						continue
 					}
 					decryptedSecret, err := cryptoUtils.DecryptPlain(decodedSecret)
 					if err != nil {
-						logger.Errorf("SyncLockOrderFulfillments.DecryptSecret: %v %v", err, order.Edges.Provider.ID)
+						logger.WithFields(logger.Fields{
+							"Error": err,
+							"OrderID": order.ID,
+							"ProviderID": order.Edges.Provider.ID,
+						}).Errorf("Failed to decrypt provider secret for pending fulfillment")
 						continue
 					}
 
@@ -818,7 +925,15 @@ func SyncLockOrderFulfillments() {
 
 					data, err := utils.ParseJSONResponse(res.RawResponse)
 					if err != nil {
-						logger.Errorf("SyncLockOrderFulfillments: %v %v", err, payload)
+						logger.WithFields(logger.Fields{
+							"Error": err,
+							"OrderID": order.ID,
+							"ProviderID": order.Edges.Provider.ID,
+							"PayloadOrderId": payload["orderId"],
+							"PayloadCurrency": payload["currency"],
+							"PayloadPsp": payload["psp"],
+							"PayloadTxId": payload["txId"],
+						}).Errorf("Failed to parse JSON response after getting trx status from provider")
 						continue
 					}
 
@@ -918,7 +1033,12 @@ func SyncLockOrderFulfillments() {
 
 						err = services.NewPriorityQueueService().AssignLockPaymentOrder(ctx, lockPaymentOrder)
 						if err != nil {
-							logger.Errorf("SyncLockOrderFulfillments.AssignLockPaymentOrder: %v", err)
+							logger.WithFields(logger.Fields{
+								"Error": err,
+								"OrderID": order.ID,
+								"OrderKey": orderKey,
+								"GatewayID": order.GatewayID,
+							}).Errorf("Redis: Failed to reassign declined order request")
 						}
 					}
 				} else if fulfillment.ValidationStatus == lockorderfulfillment.ValidationStatusSuccess {
@@ -957,7 +1077,10 @@ func ReassignStaleOrderRequest(ctx context.Context, orderRequestChan <-chan *red
 
 		orderUUID, err := uuid.Parse(orderID)
 		if err != nil {
-			logger.Errorf("ReassignStaleOrderRequest: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"OrderID": orderID,
+			}).Errorf("ReassignStaleOrderRequest: Failed to parse order ID")
 			continue
 		}
 
@@ -970,7 +1093,11 @@ func ReassignStaleOrderRequest(ctx context.Context, orderRequestChan <-chan *red
 			WithProvisionBucket().
 			Only(ctx)
 		if err != nil {
-			logger.Errorf("ReassignStaleOrderRequest: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"OrderID": orderID,
+				"UUID": orderUUID,
+			}).Errorf("ReassignStaleOrderRequest: Failed to get order from database")
 			continue
 		}
 
@@ -990,7 +1117,13 @@ func ReassignStaleOrderRequest(ctx context.Context, orderRequestChan <-chan *red
 		// Assign the order to a provider
 		err = services.NewPriorityQueueService().AssignLockPaymentOrder(ctx, orderFields)
 		if err != nil {
-			logger.Errorf("ReassignStaleOrderRequest.AssignLockPaymentOrder: %v", err)
+			// logger.Errorf("ReassignStaleOrderRequest.AssignLockPaymentOrder: %v", err)
+			logger.WithFields(logger.Fields{
+				"Error": err,
+				"OrderID": orderID,
+				"UUID": orderUUID,
+				"GatewayID": order.GatewayID,
+			}).Errorf("ReassignStaleOrderRequest: Failed to assign order to provider")
 		}
 	}
 }
@@ -1335,32 +1468,32 @@ func StartCronJobs() {
 
 	err := ComputeMarketRate()
 	if err != nil {
-		logger.Errorf("StartCronJobs: %v", err)
+		logger.Errorf("StartCronJobs for ComputeMarketRate: %v", err)
 	}
 
 	if serverConf.Environment != "production" {
 		err = priorityQueue.ProcessBucketQueues()
 		if err != nil {
-			logger.Errorf("StartCronJobs: %v", err)
+			logger.Errorf("StartCronJobs for ProcessBucketQueues: %v", err)
 		}
 	}
 
 	// Compute market rate every 10 minutes
 	_, err = scheduler.Every(10).Minutes().Do(ComputeMarketRate)
 	if err != nil {
-		logger.Errorf("StartCronJobs: %v", err)
+		logger.Errorf("StartCronJobs for ComputeMarketRate after 10 minutes: %v", err)
 	}
 
 	// Refresh provision bucket priority queues every X minutes
 	_, err = scheduler.Every(orderConf.BucketQueueRebuildInterval).Minutes().Do(priorityQueue.ProcessBucketQueues)
 	if err != nil {
-		logger.Errorf("StartCronJobs: %v", err)
+		logger.Errorf("StartCronJobs for ProcessBucketQueues: %v", err)
 	}
 
 	// Retry failed webhook notifications every 59 minutes
 	_, err = scheduler.Every(59).Minutes().Do(RetryFailedWebhookNotifications)
 	if err != nil {
-		logger.Errorf("StartCronJobs: %v", err)
+		logger.Errorf("StartCronJobs for RetryFailedWebhookNotifications: %v", err)
 	}
 
 	// Reassign pending order requests every 13 minutes
@@ -1372,31 +1505,31 @@ func StartCronJobs() {
 	// Sync lock order fulfillments every 1 minute
 	_, err = scheduler.Every(1).Minute().Do(SyncLockOrderFulfillments)
 	if err != nil {
-		logger.Errorf("StartCronJobs: %v", err)
+		logger.Errorf("StartCronJobs for SyncLockOrderFulfillments: %v", err)
 	}
 
 	// Handle receive address validity every 31 minutes
 	_, err = scheduler.Every(31).Minutes().Do(HandleReceiveAddressValidity)
 	if err != nil {
-		logger.Errorf("StartCronJobs: %v", err)
+		logger.Errorf("StartCronJobs for HandleReceiveAddressValidity: %v", err)
 	}
 
 	// Retry stale user operations every 2 minutes
 	_, err = scheduler.Every(2).Minutes().Do(RetryStaleUserOperations)
 	if err != nil {
-		logger.Errorf("StartCronJobs: %v", err)
+		logger.Errorf("StartCronJobs for RetryStaleUserOperations: %v", err)
 	}
 
 	// Index blockchain events every 10 seconds
 	_, err = scheduler.Every(10).Seconds().Do(IndexBlockchainEvents)
 	if err != nil {
-		logger.Errorf("StartCronJobs: %v", err)
+		logger.Errorf("StartCronJobs for IndexBlockchainEvents: %v", err)
 	}
 
 	// Index linked addresses every 1 minute
 	_, err = scheduler.Every(1).Minute().Do(IndexLinkedAddresses)
 	if err != nil {
-		logger.Errorf("StartCronJobs: %v", err)
+		logger.Errorf("StartCronJobs for IndexLinkedAddresses: %v", err)
 	}
 
 	// Start scheduler

--- a/utils/logger/logger.go
+++ b/utils/logger/logger.go
@@ -2,8 +2,10 @@ package logger
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -20,11 +22,11 @@ func init() {
 	logger.Formatter = &formatter{}
 
 	config := config.ServerConfig()
-
 	if config.Environment == "production" || config.Environment == "staging" {
 		// init sentry
 		err := sentry.Init(sentry.ClientOptions{
 			Dsn: config.SentryDSN,
+			AttachStacktrace: true,
 		})
 		if err != nil {
 			logger.Fatalf("Sentry initialization failed: %v", err)
@@ -70,6 +72,47 @@ func SetLogLevel(level logrus.Level) {
 
 // Fields type, used to pass to `WithFields`.
 type Fields logrus.Fields
+
+// WithFields returns a new entry with the provided fields and automatically adds caller information.
+func WithFields(fields Fields) *logrus.Entry {
+	// Get caller information (skip 1 stack frame to get the caller of WithFields)
+	_, file, line, ok := runtime.Caller(1)
+	if ok {
+		// Extract just the filename without the full path
+		_, fileName := filepath.Split(file)
+
+		// Add caller information to fields
+		logrusFields := logrus.Fields(fields)
+		if _, exists := logrusFields["file"]; !exists {
+			logrusFields["file"] = fileName
+		}
+		if _, exists := logrusFields["line"]; !exists {
+			logrusFields["line"] = line
+		}
+
+		// Try to get function name
+		pc, _, _, funcOk := runtime.Caller(1)
+		if funcOk {
+			funcName := runtime.FuncForPC(pc).Name()
+			// Extract just the function name without the full package path
+			if lastDot := strings.LastIndex(funcName, "."); lastDot != -1 {
+				funcName = funcName[lastDot+1:]
+			}
+			if _, exists := logrusFields["function"]; !exists {
+				logrusFields["function"] = funcName
+			}
+		}
+
+		return logger.WithFields(logrusFields)
+	}
+
+	return logger.WithFields(logrus.Fields(fields))
+}
+
+// WithField returns a new entry with the provided field and automatically adds caller information.
+func WithField(key string, value interface{}) *logrus.Entry {
+	return WithFields(Fields{key: value})
+}
 
 // Debugf logs a message at level Debug on the standard logger.
 func Debugf(format string, args ...interface{}) {
@@ -127,5 +170,22 @@ func (f *formatter) Format(entry *logrus.Entry) ([]byte, error) {
 	sb.WriteString(f.prefix)
 	sb.WriteString(entry.Message)
 
+	// Add fields to the log message if there are any
+	if len(entry.Data) > 0 {
+		sb.WriteString(" | ")
+		first := true
+		for k, v := range entry.Data {
+			if first {
+				first = false
+			} else {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(k)
+			sb.WriteString("=")
+			sb.WriteString(fmt.Sprintf("%v", v))
+		}
+	}
+
+	sb.WriteString("\n")
 	return sb.Bytes(), nil
 }

--- a/utils/logger/logger.go
+++ b/utils/logger/logger.go
@@ -84,10 +84,10 @@ func WithFields(fields Fields) *logrus.Entry {
 		// Add caller information to fields
 		logrusFields := logrus.Fields(fields)
 		if _, exists := logrusFields["file"]; !exists {
-			logrusFields["file"] = fileName
+			logrusFields["File"] = fileName
 		}
 		if _, exists := logrusFields["line"]; !exists {
-			logrusFields["line"] = line
+			logrusFields["Line"] = line
 		}
 
 		// Try to get function name
@@ -99,7 +99,7 @@ func WithFields(fields Fields) *logrus.Entry {
 				funcName = funcName[lastDot+1:]
 			}
 			if _, exists := logrusFields["function"]; !exists {
-				logrusFields["function"] = funcName
+				logrusFields["Function"] = funcName
 			}
 		}
 

--- a/utils/logger/logger.go
+++ b/utils/logger/logger.go
@@ -26,7 +26,6 @@ func init() {
 		// init sentry
 		err := sentry.Init(sentry.ClientOptions{
 			Dsn: config.SentryDSN,
-			AttachStacktrace: true,
 		})
 		if err != nil {
 			logger.Fatalf("Sentry initialization failed: %v", err)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -527,7 +527,7 @@ func GetTokenRateFromQueue(tokenSymbol string, orderAmount decimal.Decimal, fiat
 			parts := strings.Split(providerData, ":")
 			if len(parts) != 5 {
 				logger.WithFields(logger.Fields{
-					"Error": err,
+					"Error": fmt.Sprintf("%v", err),
 					"ProviderData": providerData,
 					"Token": tokenSymbol,
 					"Currency": fiatCurrency,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -526,7 +526,14 @@ func GetTokenRateFromQueue(tokenSymbol string, orderAmount decimal.Decimal, fiat
 			}
 			parts := strings.Split(providerData, ":")
 			if len(parts) != 5 {
-				logger.Errorf("utils.GetTokenRateFromQueue.InvalidProviderData: %v", providerData)
+				logger.WithFields(logger.Fields{
+					"Error": err,
+					"ProviderData": providerData,
+					"Token": tokenSymbol,
+					"Currency": fiatCurrency,
+					"MinAmount": minAmount,
+					"MaxAmount": maxAmount,
+				}).Errorf("GetTokenRate.InvalidProviderData: %v", providerData)
 				continue
 			}
 


### PR DESCRIPTION
- Updated logging in `priority_queue.go` to include additional context such as Redis keys, provider IDs, and error details for better traceability.
- Improved error handling in `tasks.go` by adding more descriptive logging for RPC client connections, order operations, and refund processes.
- Enhanced the logger utility in `logger.go` to automatically include caller information (file, line, function) in log entries for easier debugging.
- Refined error logging in `utils.go` to provide more context when invalid provider data is encountered, including token and currency details.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, contracts etc.


### References

> Include any links supporting this change such as a:
>
> - closes #432
> - closes #438
>


### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this project has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

Sentry Logs sample for additional informations that are required for detailed error message:
![Screenshot 2025-04-24 at 18 09 38](https://github.com/user-attachments/assets/72144d81-706a-448a-8dd1-1a3a2107f2e5)


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
