### PR TITLE
Add Business Information Fields to Registration

### DIFF
--- a/controllers/accounts/auth.go
+++ b/controllers/accounts/auth.go
@@ -171,13 +171,25 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 			return
 		}
 
-		provider, err := tx.ProviderProfile.
+		providerCreate := tx.ProviderProfile.
 			Create().
 			AddCurrencies(fiatCurrencies...).
 			SetVisibilityMode(providerprofile.VisibilityModePrivate).
 			SetUser(user).
-			SetProvisionMode(providerprofile.ProvisionModeAuto).
-			Save(ctx)
+			SetProvisionMode(providerprofile.ProvisionModeAuto)
+
+		if payload.MonthlyVolume != nil {
+			monthlyVolumeFloat, _ := payload.MonthlyVolume.Float64()
+			if monthlyVolumeFloat <= 0 {
+				_ = tx.Rollback()
+				u.APIResponse(ctx, http.StatusBadRequest, "error",
+					"Monthly volume must be greater than zero", nil)
+				return
+			}
+			providerCreate = providerCreate.SetMonthlyVolume(monthlyVolumeFloat)
+		}
+
+		provider, err := providerCreate.Save(ctx)
 		if err != nil {
 			_ = tx.Rollback()
 			logger.Errorf("error: %v", err)
@@ -199,15 +211,49 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 
 	// Create a sender profile
 	if u.ContainsString(scopes, "sender") {
-		sender, err := tx.SenderProfile.
+		// Validate business_website if provided
+		if payload.BusinessWebsite != "" && !u.IsValidURL(payload.BusinessWebsite) {
+			_ = tx.Rollback()
+			u.APIResponse(ctx, http.StatusBadRequest, "error",
+				"Invalid business website URL", nil)
+			return
+		}
+
+		// Validate business_description length
+		if len(payload.NatureOfBusiness) > 255 {
+			_ = tx.Rollback()
+			u.APIResponse(ctx, http.StatusBadRequest, "error",
+				"Nature of business exceeds character limit", nil)
+			return
+		}
+
+		senderCreate := tx.SenderProfile.
 			Create().
-			SetUser(user).
-			Save(ctx)
+			SetUser(user)
+
+			// Set optional fields
+		if payload.MonthlyVolume != nil {
+			monthlyVolumeFloat, _ := payload.MonthlyVolume.Float64()
+			if monthlyVolumeFloat <= 0 {
+				_ = tx.Rollback()
+				u.APIResponse(ctx, http.StatusBadRequest, "error",
+					"Monthly volume must be greater than zero", nil)
+				return
+			}
+			senderCreate = senderCreate.SetMonthlyVolume(monthlyVolumeFloat)
+		}
+		if payload.BusinessWebsite != "" {
+			senderCreate = senderCreate.SetBusinessWebsite(payload.BusinessWebsite)
+		}
+		if payload.NatureOfBusiness != "" {
+			senderCreate = senderCreate.SetNatureOfBusiness(payload.NatureOfBusiness)
+		}
+
+		sender, err := senderCreate.Save(ctx)
 		if err != nil {
 			_ = tx.Rollback()
 			logger.Errorf("error: %v", err)
-			u.APIResponse(ctx, http.StatusInternalServerError, "error",
-				"Failed to create new user", nil)
+			u.APIResponse(ctx, http.StatusInternalServerError, "error", "Failed to create new user", nil)
 			return
 		}
 
@@ -217,7 +263,7 @@ func (ctrl *AuthController) Register(ctx *gin.Context) {
 			_ = tx.Rollback()
 			logger.Errorf("error: %v", err)
 			u.APIResponse(ctx, http.StatusInternalServerError, "error",
-				"Failed to create new user", nil)
+				"Failed to create API key", nil)
 			return
 		}
 	}

--- a/ent/migrate/migrations/20240905170202_sender_provider_id.sql
+++ b/ent/migrate/migrations/20240905170202_sender_provider_id.sql
@@ -1,4 +1,11 @@
 -- Modify "provider_profiles" table
-ALTER TABLE "provider_profiles" DROP COLUMN "is_partner";
+ALTER TABLE "provider_profiles" 
+    DROP COLUMN "is_partner",
+    ADD COLUMN "monthly_volume" decimal DEFAULT NULL;
+
 -- Modify "sender_profiles" table
-ALTER TABLE "sender_profiles" ADD COLUMN "provider_id" character varying NULL;
+ALTER TABLE "sender_profiles" 
+    ADD COLUMN "provider_id" character varying NULL,
+    ADD COLUMN "monthly_volume" decimal DEFAULT NULL,
+    ADD COLUMN "business_website" varchar DEFAULT NULL,
+    ADD COLUMN "nature_of_business" varchar(255) DEFAULT NULL;

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -378,6 +378,7 @@ var (
 		{Name: "identity_document", Type: field.TypeString, Nullable: true},
 		{Name: "business_document", Type: field.TypeString, Nullable: true},
 		{Name: "is_kyb_verified", Type: field.TypeBool, Default: false},
+		{Name: "monthly_volume", Type: field.TypeFloat64, Nullable: true},
 		{Name: "user_provider_profile", Type: field.TypeUUID, Unique: true},
 	}
 	// ProviderProfilesTable holds the schema information for the "provider_profiles" table.
@@ -388,7 +389,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "provider_profiles_users_provider_profile",
-				Columns:    []*schema.Column{ProviderProfilesColumns[16]},
+				Columns:    []*schema.Column{ProviderProfilesColumns[17]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -513,6 +514,9 @@ var (
 		{Name: "is_partner", Type: field.TypeBool, Default: false},
 		{Name: "is_active", Type: field.TypeBool, Default: false},
 		{Name: "updated_at", Type: field.TypeTime},
+		{Name: "monthly_volume", Type: field.TypeFloat64, Nullable: true},
+		{Name: "business_website", Type: field.TypeString, Nullable: true, Size: 255},
+		{Name: "nature_of_business", Type: field.TypeString, Nullable: true, Size: 255},
 		{Name: "user_sender_profile", Type: field.TypeUUID, Unique: true},
 	}
 	// SenderProfilesTable holds the schema information for the "sender_profiles" table.
@@ -523,7 +527,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "sender_profiles_users_sender_profile",
-				Columns:    []*schema.Column{SenderProfilesColumns[7]},
+				Columns:    []*schema.Column{SenderProfilesColumns[10]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.Cascade,
 			},

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -11614,6 +11614,8 @@ type ProviderProfileMutation struct {
 	identity_document        *string
 	business_document        *string
 	is_kyb_verified          *bool
+	monthly_volume           *float64
+	addmonthly_volume        *float64
 	clearedFields            map[string]struct{}
 	user                     *uuid.UUID
 	cleareduser              bool
@@ -12399,6 +12401,76 @@ func (m *ProviderProfileMutation) ResetIsKybVerified() {
 	m.is_kyb_verified = nil
 }
 
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (m *ProviderProfileMutation) SetMonthlyVolume(f float64) {
+	m.monthly_volume = &f
+	m.addmonthly_volume = nil
+}
+
+// MonthlyVolume returns the value of the "monthly_volume" field in the mutation.
+func (m *ProviderProfileMutation) MonthlyVolume() (r float64, exists bool) {
+	v := m.monthly_volume
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldMonthlyVolume returns the old "monthly_volume" field's value of the ProviderProfile entity.
+// If the ProviderProfile object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ProviderProfileMutation) OldMonthlyVolume(ctx context.Context) (v *float64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldMonthlyVolume is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldMonthlyVolume requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldMonthlyVolume: %w", err)
+	}
+	return oldValue.MonthlyVolume, nil
+}
+
+// AddMonthlyVolume adds f to the "monthly_volume" field.
+func (m *ProviderProfileMutation) AddMonthlyVolume(f float64) {
+	if m.addmonthly_volume != nil {
+		*m.addmonthly_volume += f
+	} else {
+		m.addmonthly_volume = &f
+	}
+}
+
+// AddedMonthlyVolume returns the value that was added to the "monthly_volume" field in this mutation.
+func (m *ProviderProfileMutation) AddedMonthlyVolume() (r float64, exists bool) {
+	v := m.addmonthly_volume
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearMonthlyVolume clears the value of the "monthly_volume" field.
+func (m *ProviderProfileMutation) ClearMonthlyVolume() {
+	m.monthly_volume = nil
+	m.addmonthly_volume = nil
+	m.clearedFields[providerprofile.FieldMonthlyVolume] = struct{}{}
+}
+
+// MonthlyVolumeCleared returns if the "monthly_volume" field was cleared in this mutation.
+func (m *ProviderProfileMutation) MonthlyVolumeCleared() bool {
+	_, ok := m.clearedFields[providerprofile.FieldMonthlyVolume]
+	return ok
+}
+
+// ResetMonthlyVolume resets all changes to the "monthly_volume" field.
+func (m *ProviderProfileMutation) ResetMonthlyVolume() {
+	m.monthly_volume = nil
+	m.addmonthly_volume = nil
+	delete(m.clearedFields, providerprofile.FieldMonthlyVolume)
+}
+
 // SetUserID sets the "user" edge to the User entity by id.
 func (m *ProviderProfileMutation) SetUserID(id uuid.UUID) {
 	m.user = &id
@@ -12766,7 +12838,7 @@ func (m *ProviderProfileMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ProviderProfileMutation) Fields() []string {
-	fields := make([]string, 0, 15)
+	fields := make([]string, 0, 16)
 	if m.trading_name != nil {
 		fields = append(fields, providerprofile.FieldTradingName)
 	}
@@ -12812,6 +12884,9 @@ func (m *ProviderProfileMutation) Fields() []string {
 	if m.is_kyb_verified != nil {
 		fields = append(fields, providerprofile.FieldIsKybVerified)
 	}
+	if m.monthly_volume != nil {
+		fields = append(fields, providerprofile.FieldMonthlyVolume)
+	}
 	return fields
 }
 
@@ -12850,6 +12925,8 @@ func (m *ProviderProfileMutation) Field(name string) (ent.Value, bool) {
 		return m.BusinessDocument()
 	case providerprofile.FieldIsKybVerified:
 		return m.IsKybVerified()
+	case providerprofile.FieldMonthlyVolume:
+		return m.MonthlyVolume()
 	}
 	return nil, false
 }
@@ -12889,6 +12966,8 @@ func (m *ProviderProfileMutation) OldField(ctx context.Context, name string) (en
 		return m.OldBusinessDocument(ctx)
 	case providerprofile.FieldIsKybVerified:
 		return m.OldIsKybVerified(ctx)
+	case providerprofile.FieldMonthlyVolume:
+		return m.OldMonthlyVolume(ctx)
 	}
 	return nil, fmt.Errorf("unknown ProviderProfile field %s", name)
 }
@@ -13003,6 +13082,13 @@ func (m *ProviderProfileMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetIsKybVerified(v)
 		return nil
+	case providerprofile.FieldMonthlyVolume:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetMonthlyVolume(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ProviderProfile field %s", name)
 }
@@ -13010,13 +13096,21 @@ func (m *ProviderProfileMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *ProviderProfileMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	if m.addmonthly_volume != nil {
+		fields = append(fields, providerprofile.FieldMonthlyVolume)
+	}
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *ProviderProfileMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case providerprofile.FieldMonthlyVolume:
+		return m.AddedMonthlyVolume()
+	}
 	return nil, false
 }
 
@@ -13025,6 +13119,13 @@ func (m *ProviderProfileMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *ProviderProfileMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case providerprofile.FieldMonthlyVolume:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddMonthlyVolume(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ProviderProfile numeric field %s", name)
 }
@@ -13059,6 +13160,9 @@ func (m *ProviderProfileMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(providerprofile.FieldBusinessDocument) {
 		fields = append(fields, providerprofile.FieldBusinessDocument)
+	}
+	if m.FieldCleared(providerprofile.FieldMonthlyVolume) {
+		fields = append(fields, providerprofile.FieldMonthlyVolume)
 	}
 	return fields
 }
@@ -13100,6 +13204,9 @@ func (m *ProviderProfileMutation) ClearField(name string) error {
 		return nil
 	case providerprofile.FieldBusinessDocument:
 		m.ClearBusinessDocument()
+		return nil
+	case providerprofile.FieldMonthlyVolume:
+		m.ClearMonthlyVolume()
 		return nil
 	}
 	return fmt.Errorf("unknown ProviderProfile nullable field %s", name)
@@ -13153,6 +13260,9 @@ func (m *ProviderProfileMutation) ResetField(name string) error {
 		return nil
 	case providerprofile.FieldIsKybVerified:
 		m.ResetIsKybVerified()
+		return nil
+	case providerprofile.FieldMonthlyVolume:
+		m.ResetMonthlyVolume()
 		return nil
 	}
 	return fmt.Errorf("unknown ProviderProfile field %s", name)
@@ -16307,6 +16417,10 @@ type SenderProfileMutation struct {
 	is_partner             *bool
 	is_active              *bool
 	updated_at             *time.Time
+	monthly_volume         *float64
+	addmonthly_volume      *float64
+	business_website       *string
+	nature_of_business     *string
 	clearedFields          map[string]struct{}
 	user                   *uuid.UUID
 	cleareduser            bool
@@ -16687,6 +16801,174 @@ func (m *SenderProfileMutation) ResetUpdatedAt() {
 	m.updated_at = nil
 }
 
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (m *SenderProfileMutation) SetMonthlyVolume(f float64) {
+	m.monthly_volume = &f
+	m.addmonthly_volume = nil
+}
+
+// MonthlyVolume returns the value of the "monthly_volume" field in the mutation.
+func (m *SenderProfileMutation) MonthlyVolume() (r float64, exists bool) {
+	v := m.monthly_volume
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldMonthlyVolume returns the old "monthly_volume" field's value of the SenderProfile entity.
+// If the SenderProfile object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SenderProfileMutation) OldMonthlyVolume(ctx context.Context) (v *float64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldMonthlyVolume is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldMonthlyVolume requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldMonthlyVolume: %w", err)
+	}
+	return oldValue.MonthlyVolume, nil
+}
+
+// AddMonthlyVolume adds f to the "monthly_volume" field.
+func (m *SenderProfileMutation) AddMonthlyVolume(f float64) {
+	if m.addmonthly_volume != nil {
+		*m.addmonthly_volume += f
+	} else {
+		m.addmonthly_volume = &f
+	}
+}
+
+// AddedMonthlyVolume returns the value that was added to the "monthly_volume" field in this mutation.
+func (m *SenderProfileMutation) AddedMonthlyVolume() (r float64, exists bool) {
+	v := m.addmonthly_volume
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearMonthlyVolume clears the value of the "monthly_volume" field.
+func (m *SenderProfileMutation) ClearMonthlyVolume() {
+	m.monthly_volume = nil
+	m.addmonthly_volume = nil
+	m.clearedFields[senderprofile.FieldMonthlyVolume] = struct{}{}
+}
+
+// MonthlyVolumeCleared returns if the "monthly_volume" field was cleared in this mutation.
+func (m *SenderProfileMutation) MonthlyVolumeCleared() bool {
+	_, ok := m.clearedFields[senderprofile.FieldMonthlyVolume]
+	return ok
+}
+
+// ResetMonthlyVolume resets all changes to the "monthly_volume" field.
+func (m *SenderProfileMutation) ResetMonthlyVolume() {
+	m.monthly_volume = nil
+	m.addmonthly_volume = nil
+	delete(m.clearedFields, senderprofile.FieldMonthlyVolume)
+}
+
+// SetBusinessWebsite sets the "business_website" field.
+func (m *SenderProfileMutation) SetBusinessWebsite(s string) {
+	m.business_website = &s
+}
+
+// BusinessWebsite returns the value of the "business_website" field in the mutation.
+func (m *SenderProfileMutation) BusinessWebsite() (r string, exists bool) {
+	v := m.business_website
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldBusinessWebsite returns the old "business_website" field's value of the SenderProfile entity.
+// If the SenderProfile object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SenderProfileMutation) OldBusinessWebsite(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldBusinessWebsite is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldBusinessWebsite requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldBusinessWebsite: %w", err)
+	}
+	return oldValue.BusinessWebsite, nil
+}
+
+// ClearBusinessWebsite clears the value of the "business_website" field.
+func (m *SenderProfileMutation) ClearBusinessWebsite() {
+	m.business_website = nil
+	m.clearedFields[senderprofile.FieldBusinessWebsite] = struct{}{}
+}
+
+// BusinessWebsiteCleared returns if the "business_website" field was cleared in this mutation.
+func (m *SenderProfileMutation) BusinessWebsiteCleared() bool {
+	_, ok := m.clearedFields[senderprofile.FieldBusinessWebsite]
+	return ok
+}
+
+// ResetBusinessWebsite resets all changes to the "business_website" field.
+func (m *SenderProfileMutation) ResetBusinessWebsite() {
+	m.business_website = nil
+	delete(m.clearedFields, senderprofile.FieldBusinessWebsite)
+}
+
+// SetNatureOfBusiness sets the "nature_of_business" field.
+func (m *SenderProfileMutation) SetNatureOfBusiness(s string) {
+	m.nature_of_business = &s
+}
+
+// NatureOfBusiness returns the value of the "nature_of_business" field in the mutation.
+func (m *SenderProfileMutation) NatureOfBusiness() (r string, exists bool) {
+	v := m.nature_of_business
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldNatureOfBusiness returns the old "nature_of_business" field's value of the SenderProfile entity.
+// If the SenderProfile object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SenderProfileMutation) OldNatureOfBusiness(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldNatureOfBusiness is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldNatureOfBusiness requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldNatureOfBusiness: %w", err)
+	}
+	return oldValue.NatureOfBusiness, nil
+}
+
+// ClearNatureOfBusiness clears the value of the "nature_of_business" field.
+func (m *SenderProfileMutation) ClearNatureOfBusiness() {
+	m.nature_of_business = nil
+	m.clearedFields[senderprofile.FieldNatureOfBusiness] = struct{}{}
+}
+
+// NatureOfBusinessCleared returns if the "nature_of_business" field was cleared in this mutation.
+func (m *SenderProfileMutation) NatureOfBusinessCleared() bool {
+	_, ok := m.clearedFields[senderprofile.FieldNatureOfBusiness]
+	return ok
+}
+
+// ResetNatureOfBusiness resets all changes to the "nature_of_business" field.
+func (m *SenderProfileMutation) ResetNatureOfBusiness() {
+	m.nature_of_business = nil
+	delete(m.clearedFields, senderprofile.FieldNatureOfBusiness)
+}
+
 // SetUserID sets the "user" edge to the User entity by id.
 func (m *SenderProfileMutation) SetUserID(id uuid.UUID) {
 	m.user = &id
@@ -16961,7 +17243,7 @@ func (m *SenderProfileMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SenderProfileMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 9)
 	if m.webhook_url != nil {
 		fields = append(fields, senderprofile.FieldWebhookURL)
 	}
@@ -16979,6 +17261,15 @@ func (m *SenderProfileMutation) Fields() []string {
 	}
 	if m.updated_at != nil {
 		fields = append(fields, senderprofile.FieldUpdatedAt)
+	}
+	if m.monthly_volume != nil {
+		fields = append(fields, senderprofile.FieldMonthlyVolume)
+	}
+	if m.business_website != nil {
+		fields = append(fields, senderprofile.FieldBusinessWebsite)
+	}
+	if m.nature_of_business != nil {
+		fields = append(fields, senderprofile.FieldNatureOfBusiness)
 	}
 	return fields
 }
@@ -17000,6 +17291,12 @@ func (m *SenderProfileMutation) Field(name string) (ent.Value, bool) {
 		return m.IsActive()
 	case senderprofile.FieldUpdatedAt:
 		return m.UpdatedAt()
+	case senderprofile.FieldMonthlyVolume:
+		return m.MonthlyVolume()
+	case senderprofile.FieldBusinessWebsite:
+		return m.BusinessWebsite()
+	case senderprofile.FieldNatureOfBusiness:
+		return m.NatureOfBusiness()
 	}
 	return nil, false
 }
@@ -17021,6 +17318,12 @@ func (m *SenderProfileMutation) OldField(ctx context.Context, name string) (ent.
 		return m.OldIsActive(ctx)
 	case senderprofile.FieldUpdatedAt:
 		return m.OldUpdatedAt(ctx)
+	case senderprofile.FieldMonthlyVolume:
+		return m.OldMonthlyVolume(ctx)
+	case senderprofile.FieldBusinessWebsite:
+		return m.OldBusinessWebsite(ctx)
+	case senderprofile.FieldNatureOfBusiness:
+		return m.OldNatureOfBusiness(ctx)
 	}
 	return nil, fmt.Errorf("unknown SenderProfile field %s", name)
 }
@@ -17072,6 +17375,27 @@ func (m *SenderProfileMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetUpdatedAt(v)
 		return nil
+	case senderprofile.FieldMonthlyVolume:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetMonthlyVolume(v)
+		return nil
+	case senderprofile.FieldBusinessWebsite:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetBusinessWebsite(v)
+		return nil
+	case senderprofile.FieldNatureOfBusiness:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetNatureOfBusiness(v)
+		return nil
 	}
 	return fmt.Errorf("unknown SenderProfile field %s", name)
 }
@@ -17079,13 +17403,21 @@ func (m *SenderProfileMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *SenderProfileMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	if m.addmonthly_volume != nil {
+		fields = append(fields, senderprofile.FieldMonthlyVolume)
+	}
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *SenderProfileMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case senderprofile.FieldMonthlyVolume:
+		return m.AddedMonthlyVolume()
+	}
 	return nil, false
 }
 
@@ -17094,6 +17426,13 @@ func (m *SenderProfileMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *SenderProfileMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case senderprofile.FieldMonthlyVolume:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddMonthlyVolume(v)
+		return nil
 	}
 	return fmt.Errorf("unknown SenderProfile numeric field %s", name)
 }
@@ -17107,6 +17446,15 @@ func (m *SenderProfileMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(senderprofile.FieldProviderID) {
 		fields = append(fields, senderprofile.FieldProviderID)
+	}
+	if m.FieldCleared(senderprofile.FieldMonthlyVolume) {
+		fields = append(fields, senderprofile.FieldMonthlyVolume)
+	}
+	if m.FieldCleared(senderprofile.FieldBusinessWebsite) {
+		fields = append(fields, senderprofile.FieldBusinessWebsite)
+	}
+	if m.FieldCleared(senderprofile.FieldNatureOfBusiness) {
+		fields = append(fields, senderprofile.FieldNatureOfBusiness)
 	}
 	return fields
 }
@@ -17127,6 +17475,15 @@ func (m *SenderProfileMutation) ClearField(name string) error {
 		return nil
 	case senderprofile.FieldProviderID:
 		m.ClearProviderID()
+		return nil
+	case senderprofile.FieldMonthlyVolume:
+		m.ClearMonthlyVolume()
+		return nil
+	case senderprofile.FieldBusinessWebsite:
+		m.ClearBusinessWebsite()
+		return nil
+	case senderprofile.FieldNatureOfBusiness:
+		m.ClearNatureOfBusiness()
 		return nil
 	}
 	return fmt.Errorf("unknown SenderProfile nullable field %s", name)
@@ -17153,6 +17510,15 @@ func (m *SenderProfileMutation) ResetField(name string) error {
 		return nil
 	case senderprofile.FieldUpdatedAt:
 		m.ResetUpdatedAt()
+		return nil
+	case senderprofile.FieldMonthlyVolume:
+		m.ResetMonthlyVolume()
+		return nil
+	case senderprofile.FieldBusinessWebsite:
+		m.ResetBusinessWebsite()
+		return nil
+	case senderprofile.FieldNatureOfBusiness:
+		m.ResetNatureOfBusiness()
 		return nil
 	}
 	return fmt.Errorf("unknown SenderProfile field %s", name)

--- a/ent/providerprofile.go
+++ b/ent/providerprofile.go
@@ -51,6 +51,8 @@ type ProviderProfile struct {
 	BusinessDocument string `json:"business_document,omitempty"`
 	// IsKybVerified holds the value of the "is_kyb_verified" field.
 	IsKybVerified bool `json:"is_kyb_verified,omitempty"`
+	// Monthly transaction volume for the provider
+	MonthlyVolume *float64 `json:"monthly_volume,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ProviderProfileQuery when eager-loading is set.
 	Edges                 ProviderProfileEdges `json:"edges"`
@@ -155,6 +157,8 @@ func (*ProviderProfile) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case providerprofile.FieldIsActive, providerprofile.FieldIsAvailable, providerprofile.FieldIsKybVerified:
 			values[i] = new(sql.NullBool)
+		case providerprofile.FieldMonthlyVolume:
+			values[i] = new(sql.NullFloat64)
 		case providerprofile.FieldID, providerprofile.FieldTradingName, providerprofile.FieldHostIdentifier, providerprofile.FieldProvisionMode, providerprofile.FieldVisibilityMode, providerprofile.FieldAddress, providerprofile.FieldMobileNumber, providerprofile.FieldBusinessName, providerprofile.FieldIdentityDocumentType, providerprofile.FieldIdentityDocument, providerprofile.FieldBusinessDocument:
 			values[i] = new(sql.NullString)
 		case providerprofile.FieldUpdatedAt, providerprofile.FieldDateOfBirth:
@@ -271,6 +275,13 @@ func (pp *ProviderProfile) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field is_kyb_verified", values[i])
 			} else if value.Valid {
 				pp.IsKybVerified = value.Bool
+			}
+		case providerprofile.FieldMonthlyVolume:
+			if value, ok := values[i].(*sql.NullFloat64); !ok {
+				return fmt.Errorf("unexpected type %T for field monthly_volume", values[i])
+			} else if value.Valid {
+				pp.MonthlyVolume = new(float64)
+				*pp.MonthlyVolume = value.Float64
 			}
 		case providerprofile.ForeignKeys[0]:
 			if value, ok := values[i].(*sql.NullScanner); !ok {
@@ -394,6 +405,11 @@ func (pp *ProviderProfile) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("is_kyb_verified=")
 	builder.WriteString(fmt.Sprintf("%v", pp.IsKybVerified))
+	builder.WriteString(", ")
+	if v := pp.MonthlyVolume; v != nil {
+		builder.WriteString("monthly_volume=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/providerprofile/providerprofile.go
+++ b/ent/providerprofile/providerprofile.go
@@ -45,6 +45,8 @@ const (
 	FieldBusinessDocument = "business_document"
 	// FieldIsKybVerified holds the string denoting the is_kyb_verified field in the database.
 	FieldIsKybVerified = "is_kyb_verified"
+	// FieldMonthlyVolume holds the string denoting the monthly_volume field in the database.
+	FieldMonthlyVolume = "monthly_volume"
 	// EdgeUser holds the string denoting the user edge name in mutations.
 	EdgeUser = "user"
 	// EdgeAPIKey holds the string denoting the api_key edge name in mutations.
@@ -126,6 +128,7 @@ var Columns = []string{
 	FieldIdentityDocument,
 	FieldBusinessDocument,
 	FieldIsKybVerified,
+	FieldMonthlyVolume,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the "provider_profiles"
@@ -332,6 +335,11 @@ func ByBusinessDocument(opts ...sql.OrderTermOption) OrderOption {
 // ByIsKybVerified orders the results by the is_kyb_verified field.
 func ByIsKybVerified(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldIsKybVerified, opts...).ToFunc()
+}
+
+// ByMonthlyVolume orders the results by the monthly_volume field.
+func ByMonthlyVolume(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldMonthlyVolume, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.

--- a/ent/providerprofile/where.go
+++ b/ent/providerprofile/where.go
@@ -125,6 +125,11 @@ func IsKybVerified(v bool) predicate.ProviderProfile {
 	return predicate.ProviderProfile(sql.FieldEQ(FieldIsKybVerified, v))
 }
 
+// MonthlyVolume applies equality check predicate on the "monthly_volume" field. It's identical to MonthlyVolumeEQ.
+func MonthlyVolume(v float64) predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldEQ(FieldMonthlyVolume, v))
+}
+
 // TradingNameEQ applies the EQ predicate on the "trading_name" field.
 func TradingNameEQ(v string) predicate.ProviderProfile {
 	return predicate.ProviderProfile(sql.FieldEQ(FieldTradingName, v))
@@ -838,6 +843,56 @@ func IsKybVerifiedEQ(v bool) predicate.ProviderProfile {
 // IsKybVerifiedNEQ applies the NEQ predicate on the "is_kyb_verified" field.
 func IsKybVerifiedNEQ(v bool) predicate.ProviderProfile {
 	return predicate.ProviderProfile(sql.FieldNEQ(FieldIsKybVerified, v))
+}
+
+// MonthlyVolumeEQ applies the EQ predicate on the "monthly_volume" field.
+func MonthlyVolumeEQ(v float64) predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldEQ(FieldMonthlyVolume, v))
+}
+
+// MonthlyVolumeNEQ applies the NEQ predicate on the "monthly_volume" field.
+func MonthlyVolumeNEQ(v float64) predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldNEQ(FieldMonthlyVolume, v))
+}
+
+// MonthlyVolumeIn applies the In predicate on the "monthly_volume" field.
+func MonthlyVolumeIn(vs ...float64) predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldIn(FieldMonthlyVolume, vs...))
+}
+
+// MonthlyVolumeNotIn applies the NotIn predicate on the "monthly_volume" field.
+func MonthlyVolumeNotIn(vs ...float64) predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldNotIn(FieldMonthlyVolume, vs...))
+}
+
+// MonthlyVolumeGT applies the GT predicate on the "monthly_volume" field.
+func MonthlyVolumeGT(v float64) predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldGT(FieldMonthlyVolume, v))
+}
+
+// MonthlyVolumeGTE applies the GTE predicate on the "monthly_volume" field.
+func MonthlyVolumeGTE(v float64) predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldGTE(FieldMonthlyVolume, v))
+}
+
+// MonthlyVolumeLT applies the LT predicate on the "monthly_volume" field.
+func MonthlyVolumeLT(v float64) predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldLT(FieldMonthlyVolume, v))
+}
+
+// MonthlyVolumeLTE applies the LTE predicate on the "monthly_volume" field.
+func MonthlyVolumeLTE(v float64) predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldLTE(FieldMonthlyVolume, v))
+}
+
+// MonthlyVolumeIsNil applies the IsNil predicate on the "monthly_volume" field.
+func MonthlyVolumeIsNil() predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldIsNull(FieldMonthlyVolume))
+}
+
+// MonthlyVolumeNotNil applies the NotNil predicate on the "monthly_volume" field.
+func MonthlyVolumeNotNil() predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldNotNull(FieldMonthlyVolume))
 }
 
 // HasUser applies the HasEdge predicate on the "user" edge.

--- a/ent/providerprofile_create.go
+++ b/ent/providerprofile_create.go
@@ -241,6 +241,20 @@ func (ppc *ProviderProfileCreate) SetNillableIsKybVerified(b *bool) *ProviderPro
 	return ppc
 }
 
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (ppc *ProviderProfileCreate) SetMonthlyVolume(f float64) *ProviderProfileCreate {
+	ppc.mutation.SetMonthlyVolume(f)
+	return ppc
+}
+
+// SetNillableMonthlyVolume sets the "monthly_volume" field if the given value is not nil.
+func (ppc *ProviderProfileCreate) SetNillableMonthlyVolume(f *float64) *ProviderProfileCreate {
+	if f != nil {
+		ppc.SetMonthlyVolume(*f)
+	}
+	return ppc
+}
+
 // SetID sets the "id" field.
 func (ppc *ProviderProfileCreate) SetID(s string) *ProviderProfileCreate {
 	ppc.mutation.SetID(s)
@@ -570,6 +584,10 @@ func (ppc *ProviderProfileCreate) createSpec() (*ProviderProfile, *sqlgraph.Crea
 	if value, ok := ppc.mutation.IsKybVerified(); ok {
 		_spec.SetField(providerprofile.FieldIsKybVerified, field.TypeBool, value)
 		_node.IsKybVerified = value
+	}
+	if value, ok := ppc.mutation.MonthlyVolume(); ok {
+		_spec.SetField(providerprofile.FieldMonthlyVolume, field.TypeFloat64, value)
+		_node.MonthlyVolume = &value
 	}
 	if nodes := ppc.mutation.UserIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -970,6 +988,30 @@ func (u *ProviderProfileUpsert) UpdateIsKybVerified() *ProviderProfileUpsert {
 	return u
 }
 
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (u *ProviderProfileUpsert) SetMonthlyVolume(v float64) *ProviderProfileUpsert {
+	u.Set(providerprofile.FieldMonthlyVolume, v)
+	return u
+}
+
+// UpdateMonthlyVolume sets the "monthly_volume" field to the value that was provided on create.
+func (u *ProviderProfileUpsert) UpdateMonthlyVolume() *ProviderProfileUpsert {
+	u.SetExcluded(providerprofile.FieldMonthlyVolume)
+	return u
+}
+
+// AddMonthlyVolume adds v to the "monthly_volume" field.
+func (u *ProviderProfileUpsert) AddMonthlyVolume(v float64) *ProviderProfileUpsert {
+	u.Add(providerprofile.FieldMonthlyVolume, v)
+	return u
+}
+
+// ClearMonthlyVolume clears the value of the "monthly_volume" field.
+func (u *ProviderProfileUpsert) ClearMonthlyVolume() *ProviderProfileUpsert {
+	u.SetNull(providerprofile.FieldMonthlyVolume)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -1288,6 +1330,34 @@ func (u *ProviderProfileUpsertOne) SetIsKybVerified(v bool) *ProviderProfileUpse
 func (u *ProviderProfileUpsertOne) UpdateIsKybVerified() *ProviderProfileUpsertOne {
 	return u.Update(func(s *ProviderProfileUpsert) {
 		s.UpdateIsKybVerified()
+	})
+}
+
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (u *ProviderProfileUpsertOne) SetMonthlyVolume(v float64) *ProviderProfileUpsertOne {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.SetMonthlyVolume(v)
+	})
+}
+
+// AddMonthlyVolume adds v to the "monthly_volume" field.
+func (u *ProviderProfileUpsertOne) AddMonthlyVolume(v float64) *ProviderProfileUpsertOne {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.AddMonthlyVolume(v)
+	})
+}
+
+// UpdateMonthlyVolume sets the "monthly_volume" field to the value that was provided on create.
+func (u *ProviderProfileUpsertOne) UpdateMonthlyVolume() *ProviderProfileUpsertOne {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.UpdateMonthlyVolume()
+	})
+}
+
+// ClearMonthlyVolume clears the value of the "monthly_volume" field.
+func (u *ProviderProfileUpsertOne) ClearMonthlyVolume() *ProviderProfileUpsertOne {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.ClearMonthlyVolume()
 	})
 }
 
@@ -1776,6 +1846,34 @@ func (u *ProviderProfileUpsertBulk) SetIsKybVerified(v bool) *ProviderProfileUps
 func (u *ProviderProfileUpsertBulk) UpdateIsKybVerified() *ProviderProfileUpsertBulk {
 	return u.Update(func(s *ProviderProfileUpsert) {
 		s.UpdateIsKybVerified()
+	})
+}
+
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (u *ProviderProfileUpsertBulk) SetMonthlyVolume(v float64) *ProviderProfileUpsertBulk {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.SetMonthlyVolume(v)
+	})
+}
+
+// AddMonthlyVolume adds v to the "monthly_volume" field.
+func (u *ProviderProfileUpsertBulk) AddMonthlyVolume(v float64) *ProviderProfileUpsertBulk {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.AddMonthlyVolume(v)
+	})
+}
+
+// UpdateMonthlyVolume sets the "monthly_volume" field to the value that was provided on create.
+func (u *ProviderProfileUpsertBulk) UpdateMonthlyVolume() *ProviderProfileUpsertBulk {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.UpdateMonthlyVolume()
+	})
+}
+
+// ClearMonthlyVolume clears the value of the "monthly_volume" field.
+func (u *ProviderProfileUpsertBulk) ClearMonthlyVolume() *ProviderProfileUpsertBulk {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.ClearMonthlyVolume()
 	})
 }
 

--- a/ent/providerprofile_update.go
+++ b/ent/providerprofile_update.go
@@ -291,6 +291,33 @@ func (ppu *ProviderProfileUpdate) SetNillableIsKybVerified(b *bool) *ProviderPro
 	return ppu
 }
 
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (ppu *ProviderProfileUpdate) SetMonthlyVolume(f float64) *ProviderProfileUpdate {
+	ppu.mutation.ResetMonthlyVolume()
+	ppu.mutation.SetMonthlyVolume(f)
+	return ppu
+}
+
+// SetNillableMonthlyVolume sets the "monthly_volume" field if the given value is not nil.
+func (ppu *ProviderProfileUpdate) SetNillableMonthlyVolume(f *float64) *ProviderProfileUpdate {
+	if f != nil {
+		ppu.SetMonthlyVolume(*f)
+	}
+	return ppu
+}
+
+// AddMonthlyVolume adds f to the "monthly_volume" field.
+func (ppu *ProviderProfileUpdate) AddMonthlyVolume(f float64) *ProviderProfileUpdate {
+	ppu.mutation.AddMonthlyVolume(f)
+	return ppu
+}
+
+// ClearMonthlyVolume clears the value of the "monthly_volume" field.
+func (ppu *ProviderProfileUpdate) ClearMonthlyVolume() *ProviderProfileUpdate {
+	ppu.mutation.ClearMonthlyVolume()
+	return ppu
+}
+
 // SetAPIKeyID sets the "api_key" edge to the APIKey entity by ID.
 func (ppu *ProviderProfileUpdate) SetAPIKeyID(id uuid.UUID) *ProviderProfileUpdate {
 	ppu.mutation.SetAPIKeyID(id)
@@ -637,6 +664,15 @@ func (ppu *ProviderProfileUpdate) sqlSave(ctx context.Context) (n int, err error
 	}
 	if value, ok := ppu.mutation.IsKybVerified(); ok {
 		_spec.SetField(providerprofile.FieldIsKybVerified, field.TypeBool, value)
+	}
+	if value, ok := ppu.mutation.MonthlyVolume(); ok {
+		_spec.SetField(providerprofile.FieldMonthlyVolume, field.TypeFloat64, value)
+	}
+	if value, ok := ppu.mutation.AddedMonthlyVolume(); ok {
+		_spec.AddField(providerprofile.FieldMonthlyVolume, field.TypeFloat64, value)
+	}
+	if ppu.mutation.MonthlyVolumeCleared() {
+		_spec.ClearField(providerprofile.FieldMonthlyVolume, field.TypeFloat64)
 	}
 	if ppu.mutation.APIKeyCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1152,6 +1188,33 @@ func (ppuo *ProviderProfileUpdateOne) SetNillableIsKybVerified(b *bool) *Provide
 	return ppuo
 }
 
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (ppuo *ProviderProfileUpdateOne) SetMonthlyVolume(f float64) *ProviderProfileUpdateOne {
+	ppuo.mutation.ResetMonthlyVolume()
+	ppuo.mutation.SetMonthlyVolume(f)
+	return ppuo
+}
+
+// SetNillableMonthlyVolume sets the "monthly_volume" field if the given value is not nil.
+func (ppuo *ProviderProfileUpdateOne) SetNillableMonthlyVolume(f *float64) *ProviderProfileUpdateOne {
+	if f != nil {
+		ppuo.SetMonthlyVolume(*f)
+	}
+	return ppuo
+}
+
+// AddMonthlyVolume adds f to the "monthly_volume" field.
+func (ppuo *ProviderProfileUpdateOne) AddMonthlyVolume(f float64) *ProviderProfileUpdateOne {
+	ppuo.mutation.AddMonthlyVolume(f)
+	return ppuo
+}
+
+// ClearMonthlyVolume clears the value of the "monthly_volume" field.
+func (ppuo *ProviderProfileUpdateOne) ClearMonthlyVolume() *ProviderProfileUpdateOne {
+	ppuo.mutation.ClearMonthlyVolume()
+	return ppuo
+}
+
 // SetAPIKeyID sets the "api_key" edge to the APIKey entity by ID.
 func (ppuo *ProviderProfileUpdateOne) SetAPIKeyID(id uuid.UUID) *ProviderProfileUpdateOne {
 	ppuo.mutation.SetAPIKeyID(id)
@@ -1528,6 +1591,15 @@ func (ppuo *ProviderProfileUpdateOne) sqlSave(ctx context.Context) (_node *Provi
 	}
 	if value, ok := ppuo.mutation.IsKybVerified(); ok {
 		_spec.SetField(providerprofile.FieldIsKybVerified, field.TypeBool, value)
+	}
+	if value, ok := ppuo.mutation.MonthlyVolume(); ok {
+		_spec.SetField(providerprofile.FieldMonthlyVolume, field.TypeFloat64, value)
+	}
+	if value, ok := ppuo.mutation.AddedMonthlyVolume(); ok {
+		_spec.AddField(providerprofile.FieldMonthlyVolume, field.TypeFloat64, value)
+	}
+	if ppuo.mutation.MonthlyVolumeCleared() {
+		_spec.ClearField(providerprofile.FieldMonthlyVolume, field.TypeFloat64)
 	}
 	if ppuo.mutation.APIKeyCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/runtime/runtime.go
+++ b/ent/runtime/runtime.go
@@ -371,6 +371,28 @@ func init() {
 	senderprofile.DefaultUpdatedAt = senderprofileDescUpdatedAt.Default.(func() time.Time)
 	// senderprofile.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	senderprofile.UpdateDefaultUpdatedAt = senderprofileDescUpdatedAt.UpdateDefault.(func() time.Time)
+	// senderprofileDescBusinessWebsite is the schema descriptor for business_website field.
+	senderprofileDescBusinessWebsite := senderprofileFields[8].Descriptor()
+	// senderprofile.BusinessWebsiteValidator is a validator for the "business_website" field. It is called by the builders before save.
+	senderprofile.BusinessWebsiteValidator = func() func(string) error {
+		validators := senderprofileDescBusinessWebsite.Validators
+		fns := [...]func(string) error{
+			validators[0].(func(string) error),
+			validators[1].(func(string) error),
+		}
+		return func(business_website string) error {
+			for _, fn := range fns {
+				if err := fn(business_website); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}()
+	// senderprofileDescNatureOfBusiness is the schema descriptor for nature_of_business field.
+	senderprofileDescNatureOfBusiness := senderprofileFields[9].Descriptor()
+	// senderprofile.NatureOfBusinessValidator is a validator for the "nature_of_business" field. It is called by the builders before save.
+	senderprofile.NatureOfBusinessValidator = senderprofileDescNatureOfBusiness.Validators[0].(func(string) error)
 	// senderprofileDescID is the schema descriptor for id field.
 	senderprofileDescID := senderprofileFields[0].Descriptor()
 	// senderprofile.DefaultID holds the default value on creation for the id field.

--- a/ent/schema/providerprofile.go
+++ b/ent/schema/providerprofile.go
@@ -50,6 +50,10 @@ func (ProviderProfile) Fields() []ent.Field {
 		field.String("identity_document").Optional(),
 		field.String("business_document").Optional(),
 		field.Bool("is_kyb_verified").Default(false),
+		field.Float("monthly_volume").
+			Optional().
+			Nillable().
+			Comment("Monthly transaction volume for the provider"),
 	}
 }
 

--- a/ent/schema/senderprofile.go
+++ b/ent/schema/senderprofile.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"regexp"
 	"time"
 
 	"entgo.io/ent"
@@ -30,6 +31,19 @@ func (SenderProfile) Fields() []ent.Field {
 		field.Time("updated_at").
 			Default(time.Now).
 			UpdateDefault(time.Now),
+		field.Float("monthly_volume").
+			Optional().
+			Nillable().
+			Comment("Monthly transaction volume for the sender"),
+		field.String("business_website").
+			Optional().
+			MaxLen(255).
+			Match(regexp.MustCompile(`^https?:\/\/.*`)).
+			Comment("Business website URL"),
+		field.String("nature_of_business").
+			Optional().
+			MaxLen(255).
+			Comment("Nature of business description"),
 	}
 }
 

--- a/ent/senderprofile.go
+++ b/ent/senderprofile.go
@@ -33,6 +33,12 @@ type SenderProfile struct {
 	IsActive bool `json:"is_active,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	// Monthly transaction volume for the sender
+	MonthlyVolume *float64 `json:"monthly_volume,omitempty"`
+	// Business website URL
+	BusinessWebsite string `json:"business_website,omitempty"`
+	// Nature of business description
+	NatureOfBusiness string `json:"nature_of_business,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the SenderProfileQuery when eager-loading is set.
 	Edges               SenderProfileEdges `json:"edges"`
@@ -115,7 +121,9 @@ func (*SenderProfile) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case senderprofile.FieldIsPartner, senderprofile.FieldIsActive:
 			values[i] = new(sql.NullBool)
-		case senderprofile.FieldWebhookURL, senderprofile.FieldProviderID:
+		case senderprofile.FieldMonthlyVolume:
+			values[i] = new(sql.NullFloat64)
+		case senderprofile.FieldWebhookURL, senderprofile.FieldProviderID, senderprofile.FieldBusinessWebsite, senderprofile.FieldNatureOfBusiness:
 			values[i] = new(sql.NullString)
 		case senderprofile.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -181,6 +189,25 @@ func (sp *SenderProfile) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field updated_at", values[i])
 			} else if value.Valid {
 				sp.UpdatedAt = value.Time
+			}
+		case senderprofile.FieldMonthlyVolume:
+			if value, ok := values[i].(*sql.NullFloat64); !ok {
+				return fmt.Errorf("unexpected type %T for field monthly_volume", values[i])
+			} else if value.Valid {
+				sp.MonthlyVolume = new(float64)
+				*sp.MonthlyVolume = value.Float64
+			}
+		case senderprofile.FieldBusinessWebsite:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field business_website", values[i])
+			} else if value.Valid {
+				sp.BusinessWebsite = value.String
+			}
+		case senderprofile.FieldNatureOfBusiness:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field nature_of_business", values[i])
+			} else if value.Valid {
+				sp.NatureOfBusiness = value.String
 			}
 		case senderprofile.ForeignKeys[0]:
 			if value, ok := values[i].(*sql.NullScanner); !ok {
@@ -267,6 +294,17 @@ func (sp *SenderProfile) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("updated_at=")
 	builder.WriteString(sp.UpdatedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	if v := sp.MonthlyVolume; v != nil {
+		builder.WriteString("monthly_volume=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	builder.WriteString("business_website=")
+	builder.WriteString(sp.BusinessWebsite)
+	builder.WriteString(", ")
+	builder.WriteString("nature_of_business=")
+	builder.WriteString(sp.NatureOfBusiness)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/senderprofile/senderprofile.go
+++ b/ent/senderprofile/senderprofile.go
@@ -27,6 +27,12 @@ const (
 	FieldIsActive = "is_active"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
 	FieldUpdatedAt = "updated_at"
+	// FieldMonthlyVolume holds the string denoting the monthly_volume field in the database.
+	FieldMonthlyVolume = "monthly_volume"
+	// FieldBusinessWebsite holds the string denoting the business_website field in the database.
+	FieldBusinessWebsite = "business_website"
+	// FieldNatureOfBusiness holds the string denoting the nature_of_business field in the database.
+	FieldNatureOfBusiness = "nature_of_business"
 	// EdgeUser holds the string denoting the user edge name in mutations.
 	EdgeUser = "user"
 	// EdgeAPIKey holds the string denoting the api_key edge name in mutations.
@@ -85,6 +91,9 @@ var Columns = []string{
 	FieldIsPartner,
 	FieldIsActive,
 	FieldUpdatedAt,
+	FieldMonthlyVolume,
+	FieldBusinessWebsite,
+	FieldNatureOfBusiness,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the "sender_profiles"
@@ -119,6 +128,10 @@ var (
 	DefaultUpdatedAt func() time.Time
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.
 	UpdateDefaultUpdatedAt func() time.Time
+	// BusinessWebsiteValidator is a validator for the "business_website" field. It is called by the builders before save.
+	BusinessWebsiteValidator func(string) error
+	// NatureOfBusinessValidator is a validator for the "nature_of_business" field. It is called by the builders before save.
+	NatureOfBusinessValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuid.UUID
 )
@@ -154,6 +167,21 @@ func ByIsActive(opts ...sql.OrderTermOption) OrderOption {
 // ByUpdatedAt orders the results by the updated_at field.
 func ByUpdatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUpdatedAt, opts...).ToFunc()
+}
+
+// ByMonthlyVolume orders the results by the monthly_volume field.
+func ByMonthlyVolume(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldMonthlyVolume, opts...).ToFunc()
+}
+
+// ByBusinessWebsite orders the results by the business_website field.
+func ByBusinessWebsite(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldBusinessWebsite, opts...).ToFunc()
+}
+
+// ByNatureOfBusiness orders the results by the nature_of_business field.
+func ByNatureOfBusiness(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldNatureOfBusiness, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.

--- a/ent/senderprofile/where.go
+++ b/ent/senderprofile/where.go
@@ -81,6 +81,21 @@ func UpdatedAt(v time.Time) predicate.SenderProfile {
 	return predicate.SenderProfile(sql.FieldEQ(FieldUpdatedAt, v))
 }
 
+// MonthlyVolume applies equality check predicate on the "monthly_volume" field. It's identical to MonthlyVolumeEQ.
+func MonthlyVolume(v float64) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldEQ(FieldMonthlyVolume, v))
+}
+
+// BusinessWebsite applies equality check predicate on the "business_website" field. It's identical to BusinessWebsiteEQ.
+func BusinessWebsite(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldEQ(FieldBusinessWebsite, v))
+}
+
+// NatureOfBusiness applies equality check predicate on the "nature_of_business" field. It's identical to NatureOfBusinessEQ.
+func NatureOfBusiness(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldEQ(FieldNatureOfBusiness, v))
+}
+
 // WebhookURLEQ applies the EQ predicate on the "webhook_url" field.
 func WebhookURLEQ(v string) predicate.SenderProfile {
 	return predicate.SenderProfile(sql.FieldEQ(FieldWebhookURL, v))
@@ -289,6 +304,206 @@ func UpdatedAtLT(v time.Time) predicate.SenderProfile {
 // UpdatedAtLTE applies the LTE predicate on the "updated_at" field.
 func UpdatedAtLTE(v time.Time) predicate.SenderProfile {
 	return predicate.SenderProfile(sql.FieldLTE(FieldUpdatedAt, v))
+}
+
+// MonthlyVolumeEQ applies the EQ predicate on the "monthly_volume" field.
+func MonthlyVolumeEQ(v float64) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldEQ(FieldMonthlyVolume, v))
+}
+
+// MonthlyVolumeNEQ applies the NEQ predicate on the "monthly_volume" field.
+func MonthlyVolumeNEQ(v float64) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldNEQ(FieldMonthlyVolume, v))
+}
+
+// MonthlyVolumeIn applies the In predicate on the "monthly_volume" field.
+func MonthlyVolumeIn(vs ...float64) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldIn(FieldMonthlyVolume, vs...))
+}
+
+// MonthlyVolumeNotIn applies the NotIn predicate on the "monthly_volume" field.
+func MonthlyVolumeNotIn(vs ...float64) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldNotIn(FieldMonthlyVolume, vs...))
+}
+
+// MonthlyVolumeGT applies the GT predicate on the "monthly_volume" field.
+func MonthlyVolumeGT(v float64) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldGT(FieldMonthlyVolume, v))
+}
+
+// MonthlyVolumeGTE applies the GTE predicate on the "monthly_volume" field.
+func MonthlyVolumeGTE(v float64) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldGTE(FieldMonthlyVolume, v))
+}
+
+// MonthlyVolumeLT applies the LT predicate on the "monthly_volume" field.
+func MonthlyVolumeLT(v float64) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldLT(FieldMonthlyVolume, v))
+}
+
+// MonthlyVolumeLTE applies the LTE predicate on the "monthly_volume" field.
+func MonthlyVolumeLTE(v float64) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldLTE(FieldMonthlyVolume, v))
+}
+
+// MonthlyVolumeIsNil applies the IsNil predicate on the "monthly_volume" field.
+func MonthlyVolumeIsNil() predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldIsNull(FieldMonthlyVolume))
+}
+
+// MonthlyVolumeNotNil applies the NotNil predicate on the "monthly_volume" field.
+func MonthlyVolumeNotNil() predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldNotNull(FieldMonthlyVolume))
+}
+
+// BusinessWebsiteEQ applies the EQ predicate on the "business_website" field.
+func BusinessWebsiteEQ(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldEQ(FieldBusinessWebsite, v))
+}
+
+// BusinessWebsiteNEQ applies the NEQ predicate on the "business_website" field.
+func BusinessWebsiteNEQ(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldNEQ(FieldBusinessWebsite, v))
+}
+
+// BusinessWebsiteIn applies the In predicate on the "business_website" field.
+func BusinessWebsiteIn(vs ...string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldIn(FieldBusinessWebsite, vs...))
+}
+
+// BusinessWebsiteNotIn applies the NotIn predicate on the "business_website" field.
+func BusinessWebsiteNotIn(vs ...string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldNotIn(FieldBusinessWebsite, vs...))
+}
+
+// BusinessWebsiteGT applies the GT predicate on the "business_website" field.
+func BusinessWebsiteGT(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldGT(FieldBusinessWebsite, v))
+}
+
+// BusinessWebsiteGTE applies the GTE predicate on the "business_website" field.
+func BusinessWebsiteGTE(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldGTE(FieldBusinessWebsite, v))
+}
+
+// BusinessWebsiteLT applies the LT predicate on the "business_website" field.
+func BusinessWebsiteLT(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldLT(FieldBusinessWebsite, v))
+}
+
+// BusinessWebsiteLTE applies the LTE predicate on the "business_website" field.
+func BusinessWebsiteLTE(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldLTE(FieldBusinessWebsite, v))
+}
+
+// BusinessWebsiteContains applies the Contains predicate on the "business_website" field.
+func BusinessWebsiteContains(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldContains(FieldBusinessWebsite, v))
+}
+
+// BusinessWebsiteHasPrefix applies the HasPrefix predicate on the "business_website" field.
+func BusinessWebsiteHasPrefix(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldHasPrefix(FieldBusinessWebsite, v))
+}
+
+// BusinessWebsiteHasSuffix applies the HasSuffix predicate on the "business_website" field.
+func BusinessWebsiteHasSuffix(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldHasSuffix(FieldBusinessWebsite, v))
+}
+
+// BusinessWebsiteIsNil applies the IsNil predicate on the "business_website" field.
+func BusinessWebsiteIsNil() predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldIsNull(FieldBusinessWebsite))
+}
+
+// BusinessWebsiteNotNil applies the NotNil predicate on the "business_website" field.
+func BusinessWebsiteNotNil() predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldNotNull(FieldBusinessWebsite))
+}
+
+// BusinessWebsiteEqualFold applies the EqualFold predicate on the "business_website" field.
+func BusinessWebsiteEqualFold(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldEqualFold(FieldBusinessWebsite, v))
+}
+
+// BusinessWebsiteContainsFold applies the ContainsFold predicate on the "business_website" field.
+func BusinessWebsiteContainsFold(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldContainsFold(FieldBusinessWebsite, v))
+}
+
+// NatureOfBusinessEQ applies the EQ predicate on the "nature_of_business" field.
+func NatureOfBusinessEQ(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldEQ(FieldNatureOfBusiness, v))
+}
+
+// NatureOfBusinessNEQ applies the NEQ predicate on the "nature_of_business" field.
+func NatureOfBusinessNEQ(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldNEQ(FieldNatureOfBusiness, v))
+}
+
+// NatureOfBusinessIn applies the In predicate on the "nature_of_business" field.
+func NatureOfBusinessIn(vs ...string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldIn(FieldNatureOfBusiness, vs...))
+}
+
+// NatureOfBusinessNotIn applies the NotIn predicate on the "nature_of_business" field.
+func NatureOfBusinessNotIn(vs ...string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldNotIn(FieldNatureOfBusiness, vs...))
+}
+
+// NatureOfBusinessGT applies the GT predicate on the "nature_of_business" field.
+func NatureOfBusinessGT(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldGT(FieldNatureOfBusiness, v))
+}
+
+// NatureOfBusinessGTE applies the GTE predicate on the "nature_of_business" field.
+func NatureOfBusinessGTE(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldGTE(FieldNatureOfBusiness, v))
+}
+
+// NatureOfBusinessLT applies the LT predicate on the "nature_of_business" field.
+func NatureOfBusinessLT(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldLT(FieldNatureOfBusiness, v))
+}
+
+// NatureOfBusinessLTE applies the LTE predicate on the "nature_of_business" field.
+func NatureOfBusinessLTE(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldLTE(FieldNatureOfBusiness, v))
+}
+
+// NatureOfBusinessContains applies the Contains predicate on the "nature_of_business" field.
+func NatureOfBusinessContains(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldContains(FieldNatureOfBusiness, v))
+}
+
+// NatureOfBusinessHasPrefix applies the HasPrefix predicate on the "nature_of_business" field.
+func NatureOfBusinessHasPrefix(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldHasPrefix(FieldNatureOfBusiness, v))
+}
+
+// NatureOfBusinessHasSuffix applies the HasSuffix predicate on the "nature_of_business" field.
+func NatureOfBusinessHasSuffix(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldHasSuffix(FieldNatureOfBusiness, v))
+}
+
+// NatureOfBusinessIsNil applies the IsNil predicate on the "nature_of_business" field.
+func NatureOfBusinessIsNil() predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldIsNull(FieldNatureOfBusiness))
+}
+
+// NatureOfBusinessNotNil applies the NotNil predicate on the "nature_of_business" field.
+func NatureOfBusinessNotNil() predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldNotNull(FieldNatureOfBusiness))
+}
+
+// NatureOfBusinessEqualFold applies the EqualFold predicate on the "nature_of_business" field.
+func NatureOfBusinessEqualFold(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldEqualFold(FieldNatureOfBusiness, v))
+}
+
+// NatureOfBusinessContainsFold applies the ContainsFold predicate on the "nature_of_business" field.
+func NatureOfBusinessContainsFold(v string) predicate.SenderProfile {
+	return predicate.SenderProfile(sql.FieldContainsFold(FieldNatureOfBusiness, v))
 }
 
 // HasUser applies the HasEdge predicate on the "user" edge.

--- a/ent/senderprofile_create.go
+++ b/ent/senderprofile_create.go
@@ -105,6 +105,48 @@ func (spc *SenderProfileCreate) SetNillableUpdatedAt(t *time.Time) *SenderProfil
 	return spc
 }
 
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (spc *SenderProfileCreate) SetMonthlyVolume(f float64) *SenderProfileCreate {
+	spc.mutation.SetMonthlyVolume(f)
+	return spc
+}
+
+// SetNillableMonthlyVolume sets the "monthly_volume" field if the given value is not nil.
+func (spc *SenderProfileCreate) SetNillableMonthlyVolume(f *float64) *SenderProfileCreate {
+	if f != nil {
+		spc.SetMonthlyVolume(*f)
+	}
+	return spc
+}
+
+// SetBusinessWebsite sets the "business_website" field.
+func (spc *SenderProfileCreate) SetBusinessWebsite(s string) *SenderProfileCreate {
+	spc.mutation.SetBusinessWebsite(s)
+	return spc
+}
+
+// SetNillableBusinessWebsite sets the "business_website" field if the given value is not nil.
+func (spc *SenderProfileCreate) SetNillableBusinessWebsite(s *string) *SenderProfileCreate {
+	if s != nil {
+		spc.SetBusinessWebsite(*s)
+	}
+	return spc
+}
+
+// SetNatureOfBusiness sets the "nature_of_business" field.
+func (spc *SenderProfileCreate) SetNatureOfBusiness(s string) *SenderProfileCreate {
+	spc.mutation.SetNatureOfBusiness(s)
+	return spc
+}
+
+// SetNillableNatureOfBusiness sets the "nature_of_business" field if the given value is not nil.
+func (spc *SenderProfileCreate) SetNillableNatureOfBusiness(s *string) *SenderProfileCreate {
+	if s != nil {
+		spc.SetNatureOfBusiness(*s)
+	}
+	return spc
+}
+
 // SetID sets the "id" field.
 func (spc *SenderProfileCreate) SetID(u uuid.UUID) *SenderProfileCreate {
 	spc.mutation.SetID(u)
@@ -265,6 +307,16 @@ func (spc *SenderProfileCreate) check() error {
 	if _, ok := spc.mutation.UpdatedAt(); !ok {
 		return &ValidationError{Name: "updated_at", err: errors.New(`ent: missing required field "SenderProfile.updated_at"`)}
 	}
+	if v, ok := spc.mutation.BusinessWebsite(); ok {
+		if err := senderprofile.BusinessWebsiteValidator(v); err != nil {
+			return &ValidationError{Name: "business_website", err: fmt.Errorf(`ent: validator failed for field "SenderProfile.business_website": %w`, err)}
+		}
+	}
+	if v, ok := spc.mutation.NatureOfBusiness(); ok {
+		if err := senderprofile.NatureOfBusinessValidator(v); err != nil {
+			return &ValidationError{Name: "nature_of_business", err: fmt.Errorf(`ent: validator failed for field "SenderProfile.nature_of_business": %w`, err)}
+		}
+	}
 	if len(spc.mutation.UserIDs()) == 0 {
 		return &ValidationError{Name: "user", err: errors.New(`ent: missing required edge "SenderProfile.user"`)}
 	}
@@ -327,6 +379,18 @@ func (spc *SenderProfileCreate) createSpec() (*SenderProfile, *sqlgraph.CreateSp
 	if value, ok := spc.mutation.UpdatedAt(); ok {
 		_spec.SetField(senderprofile.FieldUpdatedAt, field.TypeTime, value)
 		_node.UpdatedAt = value
+	}
+	if value, ok := spc.mutation.MonthlyVolume(); ok {
+		_spec.SetField(senderprofile.FieldMonthlyVolume, field.TypeFloat64, value)
+		_node.MonthlyVolume = &value
+	}
+	if value, ok := spc.mutation.BusinessWebsite(); ok {
+		_spec.SetField(senderprofile.FieldBusinessWebsite, field.TypeString, value)
+		_node.BusinessWebsite = value
+	}
+	if value, ok := spc.mutation.NatureOfBusiness(); ok {
+		_spec.SetField(senderprofile.FieldNatureOfBusiness, field.TypeString, value)
+		_node.NatureOfBusiness = value
 	}
 	if nodes := spc.mutation.UserIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -545,6 +609,66 @@ func (u *SenderProfileUpsert) UpdateUpdatedAt() *SenderProfileUpsert {
 	return u
 }
 
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (u *SenderProfileUpsert) SetMonthlyVolume(v float64) *SenderProfileUpsert {
+	u.Set(senderprofile.FieldMonthlyVolume, v)
+	return u
+}
+
+// UpdateMonthlyVolume sets the "monthly_volume" field to the value that was provided on create.
+func (u *SenderProfileUpsert) UpdateMonthlyVolume() *SenderProfileUpsert {
+	u.SetExcluded(senderprofile.FieldMonthlyVolume)
+	return u
+}
+
+// AddMonthlyVolume adds v to the "monthly_volume" field.
+func (u *SenderProfileUpsert) AddMonthlyVolume(v float64) *SenderProfileUpsert {
+	u.Add(senderprofile.FieldMonthlyVolume, v)
+	return u
+}
+
+// ClearMonthlyVolume clears the value of the "monthly_volume" field.
+func (u *SenderProfileUpsert) ClearMonthlyVolume() *SenderProfileUpsert {
+	u.SetNull(senderprofile.FieldMonthlyVolume)
+	return u
+}
+
+// SetBusinessWebsite sets the "business_website" field.
+func (u *SenderProfileUpsert) SetBusinessWebsite(v string) *SenderProfileUpsert {
+	u.Set(senderprofile.FieldBusinessWebsite, v)
+	return u
+}
+
+// UpdateBusinessWebsite sets the "business_website" field to the value that was provided on create.
+func (u *SenderProfileUpsert) UpdateBusinessWebsite() *SenderProfileUpsert {
+	u.SetExcluded(senderprofile.FieldBusinessWebsite)
+	return u
+}
+
+// ClearBusinessWebsite clears the value of the "business_website" field.
+func (u *SenderProfileUpsert) ClearBusinessWebsite() *SenderProfileUpsert {
+	u.SetNull(senderprofile.FieldBusinessWebsite)
+	return u
+}
+
+// SetNatureOfBusiness sets the "nature_of_business" field.
+func (u *SenderProfileUpsert) SetNatureOfBusiness(v string) *SenderProfileUpsert {
+	u.Set(senderprofile.FieldNatureOfBusiness, v)
+	return u
+}
+
+// UpdateNatureOfBusiness sets the "nature_of_business" field to the value that was provided on create.
+func (u *SenderProfileUpsert) UpdateNatureOfBusiness() *SenderProfileUpsert {
+	u.SetExcluded(senderprofile.FieldNatureOfBusiness)
+	return u
+}
+
+// ClearNatureOfBusiness clears the value of the "nature_of_business" field.
+func (u *SenderProfileUpsert) ClearNatureOfBusiness() *SenderProfileUpsert {
+	u.SetNull(senderprofile.FieldNatureOfBusiness)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -688,6 +812,76 @@ func (u *SenderProfileUpsertOne) SetUpdatedAt(v time.Time) *SenderProfileUpsertO
 func (u *SenderProfileUpsertOne) UpdateUpdatedAt() *SenderProfileUpsertOne {
 	return u.Update(func(s *SenderProfileUpsert) {
 		s.UpdateUpdatedAt()
+	})
+}
+
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (u *SenderProfileUpsertOne) SetMonthlyVolume(v float64) *SenderProfileUpsertOne {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.SetMonthlyVolume(v)
+	})
+}
+
+// AddMonthlyVolume adds v to the "monthly_volume" field.
+func (u *SenderProfileUpsertOne) AddMonthlyVolume(v float64) *SenderProfileUpsertOne {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.AddMonthlyVolume(v)
+	})
+}
+
+// UpdateMonthlyVolume sets the "monthly_volume" field to the value that was provided on create.
+func (u *SenderProfileUpsertOne) UpdateMonthlyVolume() *SenderProfileUpsertOne {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.UpdateMonthlyVolume()
+	})
+}
+
+// ClearMonthlyVolume clears the value of the "monthly_volume" field.
+func (u *SenderProfileUpsertOne) ClearMonthlyVolume() *SenderProfileUpsertOne {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.ClearMonthlyVolume()
+	})
+}
+
+// SetBusinessWebsite sets the "business_website" field.
+func (u *SenderProfileUpsertOne) SetBusinessWebsite(v string) *SenderProfileUpsertOne {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.SetBusinessWebsite(v)
+	})
+}
+
+// UpdateBusinessWebsite sets the "business_website" field to the value that was provided on create.
+func (u *SenderProfileUpsertOne) UpdateBusinessWebsite() *SenderProfileUpsertOne {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.UpdateBusinessWebsite()
+	})
+}
+
+// ClearBusinessWebsite clears the value of the "business_website" field.
+func (u *SenderProfileUpsertOne) ClearBusinessWebsite() *SenderProfileUpsertOne {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.ClearBusinessWebsite()
+	})
+}
+
+// SetNatureOfBusiness sets the "nature_of_business" field.
+func (u *SenderProfileUpsertOne) SetNatureOfBusiness(v string) *SenderProfileUpsertOne {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.SetNatureOfBusiness(v)
+	})
+}
+
+// UpdateNatureOfBusiness sets the "nature_of_business" field to the value that was provided on create.
+func (u *SenderProfileUpsertOne) UpdateNatureOfBusiness() *SenderProfileUpsertOne {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.UpdateNatureOfBusiness()
+	})
+}
+
+// ClearNatureOfBusiness clears the value of the "nature_of_business" field.
+func (u *SenderProfileUpsertOne) ClearNatureOfBusiness() *SenderProfileUpsertOne {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.ClearNatureOfBusiness()
 	})
 }
 
@@ -1001,6 +1195,76 @@ func (u *SenderProfileUpsertBulk) SetUpdatedAt(v time.Time) *SenderProfileUpsert
 func (u *SenderProfileUpsertBulk) UpdateUpdatedAt() *SenderProfileUpsertBulk {
 	return u.Update(func(s *SenderProfileUpsert) {
 		s.UpdateUpdatedAt()
+	})
+}
+
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (u *SenderProfileUpsertBulk) SetMonthlyVolume(v float64) *SenderProfileUpsertBulk {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.SetMonthlyVolume(v)
+	})
+}
+
+// AddMonthlyVolume adds v to the "monthly_volume" field.
+func (u *SenderProfileUpsertBulk) AddMonthlyVolume(v float64) *SenderProfileUpsertBulk {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.AddMonthlyVolume(v)
+	})
+}
+
+// UpdateMonthlyVolume sets the "monthly_volume" field to the value that was provided on create.
+func (u *SenderProfileUpsertBulk) UpdateMonthlyVolume() *SenderProfileUpsertBulk {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.UpdateMonthlyVolume()
+	})
+}
+
+// ClearMonthlyVolume clears the value of the "monthly_volume" field.
+func (u *SenderProfileUpsertBulk) ClearMonthlyVolume() *SenderProfileUpsertBulk {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.ClearMonthlyVolume()
+	})
+}
+
+// SetBusinessWebsite sets the "business_website" field.
+func (u *SenderProfileUpsertBulk) SetBusinessWebsite(v string) *SenderProfileUpsertBulk {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.SetBusinessWebsite(v)
+	})
+}
+
+// UpdateBusinessWebsite sets the "business_website" field to the value that was provided on create.
+func (u *SenderProfileUpsertBulk) UpdateBusinessWebsite() *SenderProfileUpsertBulk {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.UpdateBusinessWebsite()
+	})
+}
+
+// ClearBusinessWebsite clears the value of the "business_website" field.
+func (u *SenderProfileUpsertBulk) ClearBusinessWebsite() *SenderProfileUpsertBulk {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.ClearBusinessWebsite()
+	})
+}
+
+// SetNatureOfBusiness sets the "nature_of_business" field.
+func (u *SenderProfileUpsertBulk) SetNatureOfBusiness(v string) *SenderProfileUpsertBulk {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.SetNatureOfBusiness(v)
+	})
+}
+
+// UpdateNatureOfBusiness sets the "nature_of_business" field to the value that was provided on create.
+func (u *SenderProfileUpsertBulk) UpdateNatureOfBusiness() *SenderProfileUpsertBulk {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.UpdateNatureOfBusiness()
+	})
+}
+
+// ClearNatureOfBusiness clears the value of the "nature_of_business" field.
+func (u *SenderProfileUpsertBulk) ClearNatureOfBusiness() *SenderProfileUpsertBulk {
+	return u.Update(func(s *SenderProfileUpsert) {
+		s.ClearNatureOfBusiness()
 	})
 }
 

--- a/ent/senderprofile_update.go
+++ b/ent/senderprofile_update.go
@@ -120,6 +120,73 @@ func (spu *SenderProfileUpdate) SetUpdatedAt(t time.Time) *SenderProfileUpdate {
 	return spu
 }
 
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (spu *SenderProfileUpdate) SetMonthlyVolume(f float64) *SenderProfileUpdate {
+	spu.mutation.ResetMonthlyVolume()
+	spu.mutation.SetMonthlyVolume(f)
+	return spu
+}
+
+// SetNillableMonthlyVolume sets the "monthly_volume" field if the given value is not nil.
+func (spu *SenderProfileUpdate) SetNillableMonthlyVolume(f *float64) *SenderProfileUpdate {
+	if f != nil {
+		spu.SetMonthlyVolume(*f)
+	}
+	return spu
+}
+
+// AddMonthlyVolume adds f to the "monthly_volume" field.
+func (spu *SenderProfileUpdate) AddMonthlyVolume(f float64) *SenderProfileUpdate {
+	spu.mutation.AddMonthlyVolume(f)
+	return spu
+}
+
+// ClearMonthlyVolume clears the value of the "monthly_volume" field.
+func (spu *SenderProfileUpdate) ClearMonthlyVolume() *SenderProfileUpdate {
+	spu.mutation.ClearMonthlyVolume()
+	return spu
+}
+
+// SetBusinessWebsite sets the "business_website" field.
+func (spu *SenderProfileUpdate) SetBusinessWebsite(s string) *SenderProfileUpdate {
+	spu.mutation.SetBusinessWebsite(s)
+	return spu
+}
+
+// SetNillableBusinessWebsite sets the "business_website" field if the given value is not nil.
+func (spu *SenderProfileUpdate) SetNillableBusinessWebsite(s *string) *SenderProfileUpdate {
+	if s != nil {
+		spu.SetBusinessWebsite(*s)
+	}
+	return spu
+}
+
+// ClearBusinessWebsite clears the value of the "business_website" field.
+func (spu *SenderProfileUpdate) ClearBusinessWebsite() *SenderProfileUpdate {
+	spu.mutation.ClearBusinessWebsite()
+	return spu
+}
+
+// SetNatureOfBusiness sets the "nature_of_business" field.
+func (spu *SenderProfileUpdate) SetNatureOfBusiness(s string) *SenderProfileUpdate {
+	spu.mutation.SetNatureOfBusiness(s)
+	return spu
+}
+
+// SetNillableNatureOfBusiness sets the "nature_of_business" field if the given value is not nil.
+func (spu *SenderProfileUpdate) SetNillableNatureOfBusiness(s *string) *SenderProfileUpdate {
+	if s != nil {
+		spu.SetNatureOfBusiness(*s)
+	}
+	return spu
+}
+
+// ClearNatureOfBusiness clears the value of the "nature_of_business" field.
+func (spu *SenderProfileUpdate) ClearNatureOfBusiness() *SenderProfileUpdate {
+	spu.mutation.ClearNatureOfBusiness()
+	return spu
+}
+
 // SetAPIKeyID sets the "api_key" edge to the APIKey entity by ID.
 func (spu *SenderProfileUpdate) SetAPIKeyID(id uuid.UUID) *SenderProfileUpdate {
 	spu.mutation.SetAPIKeyID(id)
@@ -296,6 +363,16 @@ func (spu *SenderProfileUpdate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (spu *SenderProfileUpdate) check() error {
+	if v, ok := spu.mutation.BusinessWebsite(); ok {
+		if err := senderprofile.BusinessWebsiteValidator(v); err != nil {
+			return &ValidationError{Name: "business_website", err: fmt.Errorf(`ent: validator failed for field "SenderProfile.business_website": %w`, err)}
+		}
+	}
+	if v, ok := spu.mutation.NatureOfBusiness(); ok {
+		if err := senderprofile.NatureOfBusinessValidator(v); err != nil {
+			return &ValidationError{Name: "nature_of_business", err: fmt.Errorf(`ent: validator failed for field "SenderProfile.nature_of_business": %w`, err)}
+		}
+	}
 	if spu.mutation.UserCleared() && len(spu.mutation.UserIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "SenderProfile.user"`)
 	}
@@ -342,6 +419,27 @@ func (spu *SenderProfileUpdate) sqlSave(ctx context.Context) (n int, err error) 
 	}
 	if value, ok := spu.mutation.UpdatedAt(); ok {
 		_spec.SetField(senderprofile.FieldUpdatedAt, field.TypeTime, value)
+	}
+	if value, ok := spu.mutation.MonthlyVolume(); ok {
+		_spec.SetField(senderprofile.FieldMonthlyVolume, field.TypeFloat64, value)
+	}
+	if value, ok := spu.mutation.AddedMonthlyVolume(); ok {
+		_spec.AddField(senderprofile.FieldMonthlyVolume, field.TypeFloat64, value)
+	}
+	if spu.mutation.MonthlyVolumeCleared() {
+		_spec.ClearField(senderprofile.FieldMonthlyVolume, field.TypeFloat64)
+	}
+	if value, ok := spu.mutation.BusinessWebsite(); ok {
+		_spec.SetField(senderprofile.FieldBusinessWebsite, field.TypeString, value)
+	}
+	if spu.mutation.BusinessWebsiteCleared() {
+		_spec.ClearField(senderprofile.FieldBusinessWebsite, field.TypeString)
+	}
+	if value, ok := spu.mutation.NatureOfBusiness(); ok {
+		_spec.SetField(senderprofile.FieldNatureOfBusiness, field.TypeString, value)
+	}
+	if spu.mutation.NatureOfBusinessCleared() {
+		_spec.ClearField(senderprofile.FieldNatureOfBusiness, field.TypeString)
 	}
 	if spu.mutation.APIKeyCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -613,6 +711,73 @@ func (spuo *SenderProfileUpdateOne) SetUpdatedAt(t time.Time) *SenderProfileUpda
 	return spuo
 }
 
+// SetMonthlyVolume sets the "monthly_volume" field.
+func (spuo *SenderProfileUpdateOne) SetMonthlyVolume(f float64) *SenderProfileUpdateOne {
+	spuo.mutation.ResetMonthlyVolume()
+	spuo.mutation.SetMonthlyVolume(f)
+	return spuo
+}
+
+// SetNillableMonthlyVolume sets the "monthly_volume" field if the given value is not nil.
+func (spuo *SenderProfileUpdateOne) SetNillableMonthlyVolume(f *float64) *SenderProfileUpdateOne {
+	if f != nil {
+		spuo.SetMonthlyVolume(*f)
+	}
+	return spuo
+}
+
+// AddMonthlyVolume adds f to the "monthly_volume" field.
+func (spuo *SenderProfileUpdateOne) AddMonthlyVolume(f float64) *SenderProfileUpdateOne {
+	spuo.mutation.AddMonthlyVolume(f)
+	return spuo
+}
+
+// ClearMonthlyVolume clears the value of the "monthly_volume" field.
+func (spuo *SenderProfileUpdateOne) ClearMonthlyVolume() *SenderProfileUpdateOne {
+	spuo.mutation.ClearMonthlyVolume()
+	return spuo
+}
+
+// SetBusinessWebsite sets the "business_website" field.
+func (spuo *SenderProfileUpdateOne) SetBusinessWebsite(s string) *SenderProfileUpdateOne {
+	spuo.mutation.SetBusinessWebsite(s)
+	return spuo
+}
+
+// SetNillableBusinessWebsite sets the "business_website" field if the given value is not nil.
+func (spuo *SenderProfileUpdateOne) SetNillableBusinessWebsite(s *string) *SenderProfileUpdateOne {
+	if s != nil {
+		spuo.SetBusinessWebsite(*s)
+	}
+	return spuo
+}
+
+// ClearBusinessWebsite clears the value of the "business_website" field.
+func (spuo *SenderProfileUpdateOne) ClearBusinessWebsite() *SenderProfileUpdateOne {
+	spuo.mutation.ClearBusinessWebsite()
+	return spuo
+}
+
+// SetNatureOfBusiness sets the "nature_of_business" field.
+func (spuo *SenderProfileUpdateOne) SetNatureOfBusiness(s string) *SenderProfileUpdateOne {
+	spuo.mutation.SetNatureOfBusiness(s)
+	return spuo
+}
+
+// SetNillableNatureOfBusiness sets the "nature_of_business" field if the given value is not nil.
+func (spuo *SenderProfileUpdateOne) SetNillableNatureOfBusiness(s *string) *SenderProfileUpdateOne {
+	if s != nil {
+		spuo.SetNatureOfBusiness(*s)
+	}
+	return spuo
+}
+
+// ClearNatureOfBusiness clears the value of the "nature_of_business" field.
+func (spuo *SenderProfileUpdateOne) ClearNatureOfBusiness() *SenderProfileUpdateOne {
+	spuo.mutation.ClearNatureOfBusiness()
+	return spuo
+}
+
 // SetAPIKeyID sets the "api_key" edge to the APIKey entity by ID.
 func (spuo *SenderProfileUpdateOne) SetAPIKeyID(id uuid.UUID) *SenderProfileUpdateOne {
 	spuo.mutation.SetAPIKeyID(id)
@@ -802,6 +967,16 @@ func (spuo *SenderProfileUpdateOne) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (spuo *SenderProfileUpdateOne) check() error {
+	if v, ok := spuo.mutation.BusinessWebsite(); ok {
+		if err := senderprofile.BusinessWebsiteValidator(v); err != nil {
+			return &ValidationError{Name: "business_website", err: fmt.Errorf(`ent: validator failed for field "SenderProfile.business_website": %w`, err)}
+		}
+	}
+	if v, ok := spuo.mutation.NatureOfBusiness(); ok {
+		if err := senderprofile.NatureOfBusinessValidator(v); err != nil {
+			return &ValidationError{Name: "nature_of_business", err: fmt.Errorf(`ent: validator failed for field "SenderProfile.nature_of_business": %w`, err)}
+		}
+	}
 	if spuo.mutation.UserCleared() && len(spuo.mutation.UserIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "SenderProfile.user"`)
 	}
@@ -865,6 +1040,27 @@ func (spuo *SenderProfileUpdateOne) sqlSave(ctx context.Context) (_node *SenderP
 	}
 	if value, ok := spuo.mutation.UpdatedAt(); ok {
 		_spec.SetField(senderprofile.FieldUpdatedAt, field.TypeTime, value)
+	}
+	if value, ok := spuo.mutation.MonthlyVolume(); ok {
+		_spec.SetField(senderprofile.FieldMonthlyVolume, field.TypeFloat64, value)
+	}
+	if value, ok := spuo.mutation.AddedMonthlyVolume(); ok {
+		_spec.AddField(senderprofile.FieldMonthlyVolume, field.TypeFloat64, value)
+	}
+	if spuo.mutation.MonthlyVolumeCleared() {
+		_spec.ClearField(senderprofile.FieldMonthlyVolume, field.TypeFloat64)
+	}
+	if value, ok := spuo.mutation.BusinessWebsite(); ok {
+		_spec.SetField(senderprofile.FieldBusinessWebsite, field.TypeString, value)
+	}
+	if spuo.mutation.BusinessWebsiteCleared() {
+		_spec.ClearField(senderprofile.FieldBusinessWebsite, field.TypeString)
+	}
+	if value, ok := spuo.mutation.NatureOfBusiness(); ok {
+		_spec.SetField(senderprofile.FieldNatureOfBusiness, field.TypeString, value)
+	}
+	if spuo.mutation.NatureOfBusinessCleared() {
+		_spec.ClearField(senderprofile.FieldNatureOfBusiness, field.TypeString)
 	}
 	if spuo.mutation.APIKeyCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/types/types.go
+++ b/types/types.go
@@ -114,12 +114,15 @@ type CreateOrderParams struct {
 
 // RegisterPayload is the payload for the register endpoint
 type RegisterPayload struct {
-	FirstName  string   `json:"firstName" binding:"required"`
-	LastName   string   `json:"lastName" binding:"required"`
-	Email      string   `json:"email" binding:"required,email"`
-	Password   string   `json:"password" binding:"required,min=6,max=20"`
-	Currencies []string `json:"currencies"`
-	Scopes     []string `json:"scopes" binding:"required,dive,oneof=sender provider"`
+	FirstName        string           `json:"firstName" binding:"required"`
+	LastName         string           `json:"lastName" binding:"required"`
+	Email            string           `json:"email" binding:"required,email"`
+	Password         string           `json:"password" binding:"required,min=6,max=20"`
+	Currencies       []string         `json:"currencies"`
+	Scopes           []string         `json:"scopes" binding:"required,dive,oneof=sender provider"`
+	MonthlyVolume    *decimal.Decimal `json:"monthly_volume"`
+	BusinessWebsite  string           `json:"business_website"`
+	NatureOfBusiness string           `json:"nature_of_business"`
 }
 
 // RegisterResponse is the response for the register endpoint

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -393,6 +393,12 @@ func IsValidFileURL(url string) bool {
 	return matched
 }
 
+// IsValidURL checks if a string is a valid URL.
+func IsValidURL(url string) bool {
+	regex := regexp.MustCompile(`^https?://[^\s/$.?#].[^\s]*$`)
+	return regex.MatchString(url)
+}
+
 // IsValidEthereumAddress checks if a string is a valid Ethereum address
 func IsValidEthereumAddress(address string) bool {
 	pattern := `^0x[a-fA-F0-9]{40}$`


### PR DESCRIPTION
### Description

This PR implements enhanced user registration functionality by adding business-related fields and monthly volume tracking. These changes will help us better understand our users' transaction patterns and business profiles, enabling improved risk assessment and service customization.

### Key changes include:

- Added new fields to registration payload: `monthly_volume`, `business_website`, and `nature_of_business`
- Implemented database migrations for storing monthly volume in both sender and provider profiles
- Added validation logic for new fields
- Integrated analytics tracking for registration metrics
- Updated API documentation with new field descriptions


### References

Closes 455


### Testing

New unit tests have been added for:
- Monthly volume validation (positive/negative values)
- Business website URL validation
- Nature of business field validation
- Registration payload validation


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
