### PR TITLE
Fix Timezone Error in Slack Notifications

### DIFF
--- a/services/slack_test.go
+++ b/services/slack_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/paycrest/aggregator/config"
 	"github.com/paycrest/aggregator/ent"
+	"github.com/paycrest/aggregator/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -97,6 +98,28 @@ func TestSlackService(t *testing.T) {
 			err := slackService.SendUserSignupNotification(mockUser, []string{"provider"}, providerCurrencies)
 
 			assert.NoError(t, err, "unexpected error")
+		})
+
+		t.Run("FormatTimestampToGMT1 should work with any timezone configuration", func(t *testing.T) {
+			testTime := time.Date(2023, 5, 15, 14, 30, 0, 0, time.UTC)
+
+			formattedTime, err := utils.FormatTimestampToGMT1(testTime)
+
+			assert.NoError(t, err, "formatting timestamp should not produce an error")
+			assert.NotEmpty(t, formattedTime, "formatted time should not be empty")
+			assert.Contains(t, formattedTime, "May 15, 2023")
+			assert.Contains(t, formattedTime, "3:30 PM")
+		})
+
+		t.Run("FormatTimestampToGMT1 should work with current time", func(t *testing.T) {
+			// Get current time
+			now := time.Now().UTC()
+
+			formattedTime, err := utils.FormatTimestampToGMT1(now)
+
+			assert.NoError(t, err, "formatting current timestamp should not produce an error")
+			assert.NotEmpty(t, formattedTime, "formatted time should not be empty")
+			assert.Contains(t, formattedTime, now.In(time.FixedZone("GMT+1", 3600)).Format("2006"))
 		})
 	})
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -111,12 +111,9 @@ func BigMin(x, y *big.Int) *big.Int {
 	return y
 }
 
-// FormatTimestampToGMT1 formats the timestamp to GMT+1 (Africa/Lagos time zone) and returns a formatted string
+// FormatTimestampToGMT1 formats the timestamp to GMT+1 (Africa/Lagos time zone) and returns a formatted string.
 func FormatTimestampToGMT1(timestamp time.Time) (string, error) {
-	loc, err := time.LoadLocation("Africa/Lagos")
-	if err != nil {
-		return "", err
-	}
+	loc := time.FixedZone("GMT+1", 1*60*60)
 	return timestamp.In(loc).Format("January 2, 2006 at 3:04 PM"), nil
 }
 


### PR DESCRIPTION
### Description

This PR fixes an issue where Slack notifications fail with the error: `Failed to send Slack notification: error formatting timestamp: unknown time zone Africa/Lagos`.

The problem occurs when the `FormatTimestampToGMT1` function attempts to load the "Africa/Lagos" time zone, which isn't available in all environments. This causes notifications to fail in production when the time zone database doesn't contain this specific time zone.
The solution replaces the time zone loading approach with a more reliable fixed offset implementation using `time.FixedZone("GMT+1", 1*60*60)`. This ensures the function works consistently across all environments while maintaining the existing function signature.


### References

[GlitchTip](https://glitchtip.pycrst.xyz/paycrest/issues/135)


### Testing

- Unit tests have been added to specifically test the FormatTimestampToGMT1 function


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
