### PR TITLE
feat: add metadata field to payment order and recipient models

### DIFF
--- a/config/server.go
+++ b/config/server.go
@@ -33,6 +33,7 @@ func ServerConfig() *ServerConfiguration {
 	viper.SetDefault("RATE_LIMIT_UNAUTHENTICATED", 5)
 	viper.SetDefault("RATE_LIMIT_AUTHENTICATED", 100)
 	viper.SetDefault("SLACK_WEBHOOK_URL", "")
+	viper.SetDefault("SERVER_URL", "")
 
 	return &ServerConfiguration{
 		Debug:                    viper.GetBool("DEBUG"),

--- a/controllers/sender/sender.go
+++ b/controllers/sender/sender.go
@@ -414,6 +414,7 @@ func (ctrl *SenderController) InitiatePaymentOrder(ctx *gin.Context) {
 		SetAccountName(payload.Recipient.AccountName).
 		SetProviderID(payload.Recipient.ProviderID).
 		SetMemo(payload.Recipient.Memo).
+		SetMetadata(payload.Recipient.Metadata).
 		SetPaymentOrder(paymentOrder).
 		Save(ctx)
 	if err != nil {

--- a/ent/linkedaddress/linkedaddress.go
+++ b/ent/linkedaddress/linkedaddress.go
@@ -28,6 +28,8 @@ const (
 	FieldAccountIdentifier = "account_identifier"
 	// FieldAccountName holds the string denoting the account_name field in the database.
 	FieldAccountName = "account_name"
+	// FieldMetadata holds the string denoting the metadata field in the database.
+	FieldMetadata = "metadata"
 	// FieldOwnerAddress holds the string denoting the owner_address field in the database.
 	FieldOwnerAddress = "owner_address"
 	// FieldLastIndexedBlock holds the string denoting the last_indexed_block field in the database.
@@ -57,6 +59,7 @@ var Columns = []string{
 	FieldInstitution,
 	FieldAccountIdentifier,
 	FieldAccountName,
+	FieldMetadata,
 	FieldOwnerAddress,
 	FieldLastIndexedBlock,
 	FieldTxHash,

--- a/ent/linkedaddress/where.go
+++ b/ent/linkedaddress/where.go
@@ -485,6 +485,16 @@ func AccountNameContainsFold(v string) predicate.LinkedAddress {
 	return predicate.LinkedAddress(sql.FieldContainsFold(FieldAccountName, v))
 }
 
+// MetadataIsNil applies the IsNil predicate on the "metadata" field.
+func MetadataIsNil() predicate.LinkedAddress {
+	return predicate.LinkedAddress(sql.FieldIsNull(FieldMetadata))
+}
+
+// MetadataNotNil applies the NotNil predicate on the "metadata" field.
+func MetadataNotNil() predicate.LinkedAddress {
+	return predicate.LinkedAddress(sql.FieldNotNull(FieldMetadata))
+}
+
 // OwnerAddressEQ applies the EQ predicate on the "owner_address" field.
 func OwnerAddressEQ(v string) predicate.LinkedAddress {
 	return predicate.LinkedAddress(sql.FieldEQ(FieldOwnerAddress, v))

--- a/ent/linkedaddress_create.go
+++ b/ent/linkedaddress_create.go
@@ -82,6 +82,12 @@ func (lac *LinkedAddressCreate) SetAccountName(s string) *LinkedAddressCreate {
 	return lac
 }
 
+// SetMetadata sets the "metadata" field.
+func (lac *LinkedAddressCreate) SetMetadata(m map[string]interface{}) *LinkedAddressCreate {
+	lac.mutation.SetMetadata(m)
+	return lac
+}
+
 // SetOwnerAddress sets the "owner_address" field.
 func (lac *LinkedAddressCreate) SetOwnerAddress(s string) *LinkedAddressCreate {
 	lac.mutation.SetOwnerAddress(s)
@@ -262,6 +268,10 @@ func (lac *LinkedAddressCreate) createSpec() (*LinkedAddress, *sqlgraph.CreateSp
 		_spec.SetField(linkedaddress.FieldAccountName, field.TypeString, value)
 		_node.AccountName = value
 	}
+	if value, ok := lac.mutation.Metadata(); ok {
+		_spec.SetField(linkedaddress.FieldMetadata, field.TypeJSON, value)
+		_node.Metadata = value
+	}
 	if value, ok := lac.mutation.OwnerAddress(); ok {
 		_spec.SetField(linkedaddress.FieldOwnerAddress, field.TypeString, value)
 		_node.OwnerAddress = value
@@ -399,6 +409,24 @@ func (u *LinkedAddressUpsert) SetAccountName(v string) *LinkedAddressUpsert {
 // UpdateAccountName sets the "account_name" field to the value that was provided on create.
 func (u *LinkedAddressUpsert) UpdateAccountName() *LinkedAddressUpsert {
 	u.SetExcluded(linkedaddress.FieldAccountName)
+	return u
+}
+
+// SetMetadata sets the "metadata" field.
+func (u *LinkedAddressUpsert) SetMetadata(v map[string]interface{}) *LinkedAddressUpsert {
+	u.Set(linkedaddress.FieldMetadata, v)
+	return u
+}
+
+// UpdateMetadata sets the "metadata" field to the value that was provided on create.
+func (u *LinkedAddressUpsert) UpdateMetadata() *LinkedAddressUpsert {
+	u.SetExcluded(linkedaddress.FieldMetadata)
+	return u
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (u *LinkedAddressUpsert) ClearMetadata() *LinkedAddressUpsert {
+	u.SetNull(linkedaddress.FieldMetadata)
 	return u
 }
 
@@ -571,6 +599,27 @@ func (u *LinkedAddressUpsertOne) SetAccountName(v string) *LinkedAddressUpsertOn
 func (u *LinkedAddressUpsertOne) UpdateAccountName() *LinkedAddressUpsertOne {
 	return u.Update(func(s *LinkedAddressUpsert) {
 		s.UpdateAccountName()
+	})
+}
+
+// SetMetadata sets the "metadata" field.
+func (u *LinkedAddressUpsertOne) SetMetadata(v map[string]interface{}) *LinkedAddressUpsertOne {
+	return u.Update(func(s *LinkedAddressUpsert) {
+		s.SetMetadata(v)
+	})
+}
+
+// UpdateMetadata sets the "metadata" field to the value that was provided on create.
+func (u *LinkedAddressUpsertOne) UpdateMetadata() *LinkedAddressUpsertOne {
+	return u.Update(func(s *LinkedAddressUpsert) {
+		s.UpdateMetadata()
+	})
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (u *LinkedAddressUpsertOne) ClearMetadata() *LinkedAddressUpsertOne {
+	return u.Update(func(s *LinkedAddressUpsert) {
+		s.ClearMetadata()
 	})
 }
 
@@ -918,6 +967,27 @@ func (u *LinkedAddressUpsertBulk) SetAccountName(v string) *LinkedAddressUpsertB
 func (u *LinkedAddressUpsertBulk) UpdateAccountName() *LinkedAddressUpsertBulk {
 	return u.Update(func(s *LinkedAddressUpsert) {
 		s.UpdateAccountName()
+	})
+}
+
+// SetMetadata sets the "metadata" field.
+func (u *LinkedAddressUpsertBulk) SetMetadata(v map[string]interface{}) *LinkedAddressUpsertBulk {
+	return u.Update(func(s *LinkedAddressUpsert) {
+		s.SetMetadata(v)
+	})
+}
+
+// UpdateMetadata sets the "metadata" field to the value that was provided on create.
+func (u *LinkedAddressUpsertBulk) UpdateMetadata() *LinkedAddressUpsertBulk {
+	return u.Update(func(s *LinkedAddressUpsert) {
+		s.UpdateMetadata()
+	})
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (u *LinkedAddressUpsertBulk) ClearMetadata() *LinkedAddressUpsertBulk {
+	return u.Update(func(s *LinkedAddressUpsert) {
+		s.ClearMetadata()
 	})
 }
 

--- a/ent/linkedaddress_update.go
+++ b/ent/linkedaddress_update.go
@@ -92,6 +92,18 @@ func (lau *LinkedAddressUpdate) SetNillableAccountName(s *string) *LinkedAddress
 	return lau
 }
 
+// SetMetadata sets the "metadata" field.
+func (lau *LinkedAddressUpdate) SetMetadata(m map[string]interface{}) *LinkedAddressUpdate {
+	lau.mutation.SetMetadata(m)
+	return lau
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (lau *LinkedAddressUpdate) ClearMetadata() *LinkedAddressUpdate {
+	lau.mutation.ClearMetadata()
+	return lau
+}
+
 // SetOwnerAddress sets the "owner_address" field.
 func (lau *LinkedAddressUpdate) SetOwnerAddress(s string) *LinkedAddressUpdate {
 	lau.mutation.SetOwnerAddress(s)
@@ -267,6 +279,12 @@ func (lau *LinkedAddressUpdate) sqlSave(ctx context.Context) (n int, err error) 
 	if value, ok := lau.mutation.AccountName(); ok {
 		_spec.SetField(linkedaddress.FieldAccountName, field.TypeString, value)
 	}
+	if value, ok := lau.mutation.Metadata(); ok {
+		_spec.SetField(linkedaddress.FieldMetadata, field.TypeJSON, value)
+	}
+	if lau.mutation.MetadataCleared() {
+		_spec.ClearField(linkedaddress.FieldMetadata, field.TypeJSON)
+	}
 	if value, ok := lau.mutation.OwnerAddress(); ok {
 		_spec.SetField(linkedaddress.FieldOwnerAddress, field.TypeString, value)
 	}
@@ -409,6 +427,18 @@ func (lauo *LinkedAddressUpdateOne) SetNillableAccountName(s *string) *LinkedAdd
 	if s != nil {
 		lauo.SetAccountName(*s)
 	}
+	return lauo
+}
+
+// SetMetadata sets the "metadata" field.
+func (lauo *LinkedAddressUpdateOne) SetMetadata(m map[string]interface{}) *LinkedAddressUpdateOne {
+	lauo.mutation.SetMetadata(m)
+	return lauo
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (lauo *LinkedAddressUpdateOne) ClearMetadata() *LinkedAddressUpdateOne {
+	lauo.mutation.ClearMetadata()
 	return lauo
 }
 
@@ -616,6 +646,12 @@ func (lauo *LinkedAddressUpdateOne) sqlSave(ctx context.Context) (_node *LinkedA
 	}
 	if value, ok := lauo.mutation.AccountName(); ok {
 		_spec.SetField(linkedaddress.FieldAccountName, field.TypeString, value)
+	}
+	if value, ok := lauo.mutation.Metadata(); ok {
+		_spec.SetField(linkedaddress.FieldMetadata, field.TypeJSON, value)
+	}
+	if lauo.mutation.MetadataCleared() {
+		_spec.ClearField(linkedaddress.FieldMetadata, field.TypeJSON)
 	}
 	if value, ok := lauo.mutation.OwnerAddress(); ok {
 		_spec.SetField(linkedaddress.FieldOwnerAddress, field.TypeString, value)

--- a/ent/lockpaymentorder/lockpaymentorder.go
+++ b/ent/lockpaymentorder/lockpaymentorder.go
@@ -42,6 +42,8 @@ const (
 	FieldAccountName = "account_name"
 	// FieldMemo holds the string denoting the memo field in the database.
 	FieldMemo = "memo"
+	// FieldMetadata holds the string denoting the metadata field in the database.
+	FieldMetadata = "metadata"
 	// FieldCancellationCount holds the string denoting the cancellation_count field in the database.
 	FieldCancellationCount = "cancellation_count"
 	// FieldCancellationReasons holds the string denoting the cancellation_reasons field in the database.
@@ -111,6 +113,7 @@ var Columns = []string{
 	FieldAccountIdentifier,
 	FieldAccountName,
 	FieldMemo,
+	FieldMetadata,
 	FieldCancellationCount,
 	FieldCancellationReasons,
 }

--- a/ent/lockpaymentorder/where.go
+++ b/ent/lockpaymentorder/where.go
@@ -792,6 +792,16 @@ func MemoContainsFold(v string) predicate.LockPaymentOrder {
 	return predicate.LockPaymentOrder(sql.FieldContainsFold(FieldMemo, v))
 }
 
+// MetadataIsNil applies the IsNil predicate on the "metadata" field.
+func MetadataIsNil() predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldIsNull(FieldMetadata))
+}
+
+// MetadataNotNil applies the NotNil predicate on the "metadata" field.
+func MetadataNotNil() predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldNotNull(FieldMetadata))
+}
+
 // CancellationCountEQ applies the EQ predicate on the "cancellation_count" field.
 func CancellationCountEQ(v int) predicate.LockPaymentOrder {
 	return predicate.LockPaymentOrder(sql.FieldEQ(FieldCancellationCount, v))

--- a/ent/lockpaymentorder_create.go
+++ b/ent/lockpaymentorder_create.go
@@ -148,6 +148,12 @@ func (lpoc *LockPaymentOrderCreate) SetNillableMemo(s *string) *LockPaymentOrder
 	return lpoc
 }
 
+// SetMetadata sets the "metadata" field.
+func (lpoc *LockPaymentOrderCreate) SetMetadata(m map[string]interface{}) *LockPaymentOrderCreate {
+	lpoc.mutation.SetMetadata(m)
+	return lpoc
+}
+
 // SetCancellationCount sets the "cancellation_count" field.
 func (lpoc *LockPaymentOrderCreate) SetCancellationCount(i int) *LockPaymentOrderCreate {
 	lpoc.mutation.SetCancellationCount(i)
@@ -463,6 +469,10 @@ func (lpoc *LockPaymentOrderCreate) createSpec() (*LockPaymentOrder, *sqlgraph.C
 	if value, ok := lpoc.mutation.Memo(); ok {
 		_spec.SetField(lockpaymentorder.FieldMemo, field.TypeString, value)
 		_node.Memo = value
+	}
+	if value, ok := lpoc.mutation.Metadata(); ok {
+		_spec.SetField(lockpaymentorder.FieldMetadata, field.TypeJSON, value)
+		_node.Metadata = value
 	}
 	if value, ok := lpoc.mutation.CancellationCount(); ok {
 		_spec.SetField(lockpaymentorder.FieldCancellationCount, field.TypeInt, value)
@@ -787,6 +797,24 @@ func (u *LockPaymentOrderUpsert) ClearMemo() *LockPaymentOrderUpsert {
 	return u
 }
 
+// SetMetadata sets the "metadata" field.
+func (u *LockPaymentOrderUpsert) SetMetadata(v map[string]interface{}) *LockPaymentOrderUpsert {
+	u.Set(lockpaymentorder.FieldMetadata, v)
+	return u
+}
+
+// UpdateMetadata sets the "metadata" field to the value that was provided on create.
+func (u *LockPaymentOrderUpsert) UpdateMetadata() *LockPaymentOrderUpsert {
+	u.SetExcluded(lockpaymentorder.FieldMetadata)
+	return u
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (u *LockPaymentOrderUpsert) ClearMetadata() *LockPaymentOrderUpsert {
+	u.SetNull(lockpaymentorder.FieldMetadata)
+	return u
+}
+
 // SetCancellationCount sets the "cancellation_count" field.
 func (u *LockPaymentOrderUpsert) SetCancellationCount(v int) *LockPaymentOrderUpsert {
 	u.Set(lockpaymentorder.FieldCancellationCount, v)
@@ -1075,6 +1103,27 @@ func (u *LockPaymentOrderUpsertOne) UpdateMemo() *LockPaymentOrderUpsertOne {
 func (u *LockPaymentOrderUpsertOne) ClearMemo() *LockPaymentOrderUpsertOne {
 	return u.Update(func(s *LockPaymentOrderUpsert) {
 		s.ClearMemo()
+	})
+}
+
+// SetMetadata sets the "metadata" field.
+func (u *LockPaymentOrderUpsertOne) SetMetadata(v map[string]interface{}) *LockPaymentOrderUpsertOne {
+	return u.Update(func(s *LockPaymentOrderUpsert) {
+		s.SetMetadata(v)
+	})
+}
+
+// UpdateMetadata sets the "metadata" field to the value that was provided on create.
+func (u *LockPaymentOrderUpsertOne) UpdateMetadata() *LockPaymentOrderUpsertOne {
+	return u.Update(func(s *LockPaymentOrderUpsert) {
+		s.UpdateMetadata()
+	})
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (u *LockPaymentOrderUpsertOne) ClearMetadata() *LockPaymentOrderUpsertOne {
+	return u.Update(func(s *LockPaymentOrderUpsert) {
+		s.ClearMetadata()
 	})
 }
 
@@ -1538,6 +1587,27 @@ func (u *LockPaymentOrderUpsertBulk) UpdateMemo() *LockPaymentOrderUpsertBulk {
 func (u *LockPaymentOrderUpsertBulk) ClearMemo() *LockPaymentOrderUpsertBulk {
 	return u.Update(func(s *LockPaymentOrderUpsert) {
 		s.ClearMemo()
+	})
+}
+
+// SetMetadata sets the "metadata" field.
+func (u *LockPaymentOrderUpsertBulk) SetMetadata(v map[string]interface{}) *LockPaymentOrderUpsertBulk {
+	return u.Update(func(s *LockPaymentOrderUpsert) {
+		s.SetMetadata(v)
+	})
+}
+
+// UpdateMetadata sets the "metadata" field to the value that was provided on create.
+func (u *LockPaymentOrderUpsertBulk) UpdateMetadata() *LockPaymentOrderUpsertBulk {
+	return u.Update(func(s *LockPaymentOrderUpsert) {
+		s.UpdateMetadata()
+	})
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (u *LockPaymentOrderUpsertBulk) ClearMetadata() *LockPaymentOrderUpsertBulk {
+	return u.Update(func(s *LockPaymentOrderUpsert) {
+		s.ClearMetadata()
 	})
 }
 

--- a/ent/lockpaymentorder_update.go
+++ b/ent/lockpaymentorder_update.go
@@ -236,6 +236,18 @@ func (lpou *LockPaymentOrderUpdate) ClearMemo() *LockPaymentOrderUpdate {
 	return lpou
 }
 
+// SetMetadata sets the "metadata" field.
+func (lpou *LockPaymentOrderUpdate) SetMetadata(m map[string]interface{}) *LockPaymentOrderUpdate {
+	lpou.mutation.SetMetadata(m)
+	return lpou
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (lpou *LockPaymentOrderUpdate) ClearMetadata() *LockPaymentOrderUpdate {
+	lpou.mutation.ClearMetadata()
+	return lpou
+}
+
 // SetCancellationCount sets the "cancellation_count" field.
 func (lpou *LockPaymentOrderUpdate) SetCancellationCount(i int) *LockPaymentOrderUpdate {
 	lpou.mutation.ResetCancellationCount()
@@ -532,6 +544,12 @@ func (lpou *LockPaymentOrderUpdate) sqlSave(ctx context.Context) (n int, err err
 	}
 	if lpou.mutation.MemoCleared() {
 		_spec.ClearField(lockpaymentorder.FieldMemo, field.TypeString)
+	}
+	if value, ok := lpou.mutation.Metadata(); ok {
+		_spec.SetField(lockpaymentorder.FieldMetadata, field.TypeJSON, value)
+	}
+	if lpou.mutation.MetadataCleared() {
+		_spec.ClearField(lockpaymentorder.FieldMetadata, field.TypeJSON)
 	}
 	if value, ok := lpou.mutation.CancellationCount(); ok {
 		_spec.SetField(lockpaymentorder.FieldCancellationCount, field.TypeInt, value)
@@ -944,6 +962,18 @@ func (lpouo *LockPaymentOrderUpdateOne) ClearMemo() *LockPaymentOrderUpdateOne {
 	return lpouo
 }
 
+// SetMetadata sets the "metadata" field.
+func (lpouo *LockPaymentOrderUpdateOne) SetMetadata(m map[string]interface{}) *LockPaymentOrderUpdateOne {
+	lpouo.mutation.SetMetadata(m)
+	return lpouo
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (lpouo *LockPaymentOrderUpdateOne) ClearMetadata() *LockPaymentOrderUpdateOne {
+	lpouo.mutation.ClearMetadata()
+	return lpouo
+}
+
 // SetCancellationCount sets the "cancellation_count" field.
 func (lpouo *LockPaymentOrderUpdateOne) SetCancellationCount(i int) *LockPaymentOrderUpdateOne {
 	lpouo.mutation.ResetCancellationCount()
@@ -1270,6 +1300,12 @@ func (lpouo *LockPaymentOrderUpdateOne) sqlSave(ctx context.Context) (_node *Loc
 	}
 	if lpouo.mutation.MemoCleared() {
 		_spec.ClearField(lockpaymentorder.FieldMemo, field.TypeString)
+	}
+	if value, ok := lpouo.mutation.Metadata(); ok {
+		_spec.SetField(lockpaymentorder.FieldMetadata, field.TypeJSON, value)
+	}
+	if lpouo.mutation.MetadataCleared() {
+		_spec.ClearField(lockpaymentorder.FieldMetadata, field.TypeJSON)
 	}
 	if value, ok := lpouo.mutation.CancellationCount(); ok {
 		_spec.SetField(lockpaymentorder.FieldCancellationCount, field.TypeInt, value)

--- a/ent/migrate/migrations/20250510125049_order_metadata.sql
+++ b/ent/migrate/migrations/20250510125049_order_metadata.sql
@@ -1,0 +1,6 @@
+-- Modify "lock_payment_orders" table
+ALTER TABLE "lock_payment_orders" ADD COLUMN "metadata" jsonb NULL;
+-- Modify "payment_order_recipients" table
+ALTER TABLE "payment_order_recipients" ADD COLUMN "metadata" jsonb NULL;
+-- Modify "provider_order_tokens" table
+ALTER TABLE "provider_order_tokens" ALTER COLUMN "rate_slippage" DROP DEFAULT;

--- a/ent/migrate/migrations/20250510231545_order_metadata.sql
+++ b/ent/migrate/migrations/20250510231545_order_metadata.sql
@@ -1,3 +1,5 @@
+-- Modify "linked_addresses" table
+ALTER TABLE "linked_addresses" ADD COLUMN "metadata" jsonb NULL;
 -- Modify "lock_payment_orders" table
 ALTER TABLE "lock_payment_orders" ADD COLUMN "metadata" jsonb NULL;
 -- Modify "payment_order_recipients" table

--- a/ent/migrate/migrations/atlas.sum
+++ b/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:RFlx3KmvdwrchLzsgOfySoLPJ3vjn0jCOkxzKa3wL8U=
+h1:mbjYUn+9Ft6WqrWeZurNpG+pt3iyhucaGjJHe2+C+uI=
 20240118234246_initial.sql h1:dYuYBqns33WT+3p8VQvbKUP62k3k6w6h8S+FqNqgSvU=
 20240130122324_order_from_address.sql h1:mMVI2iBUd1roIYLUqu0d2jZ7+B6exppRN8qqn+aIHx4=
 20240202010744_fees_on_order.sql h1:P7ngxZKqDKefBM5vk6M3kbWeMPVwbZ4MZVcLBjEfS34=
@@ -52,4 +52,4 @@ h1:RFlx3KmvdwrchLzsgOfySoLPJ3vjn0jCOkxzKa3wL8U=
 20250425202927_rate_slippage.sql h1:+I0bp1gHMyiZ+vTvbX+y14Xq/bFTKPmr4LeSUWddYgc=
 20250505033200_tzs_bank_institutions.sql h1:kQHdkewxxx63Z5dMQJYsq5LPL1SaeBv8hGv84fpsLCQ=
 20250505033210_ugx_bank_institutions.sql h1:8ex3xOuruqqPQJbcR9rUNpPDHU4n8Q3URvUIXQ6oDDE=
-20250510125049_order_metadata.sql h1:4/l64vbC/4ryctVMJxhVjL4bWDqC2F+00lDJRRQM62I=
+20250510231545_order_metadata.sql h1:BrHlYt3LvuYcnsw7b9xfzjg5U4D1RfPy+RusxRDj66k=

--- a/ent/migrate/migrations/atlas.sum
+++ b/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:j3Xw40bQvqen66wzxvMN3gcAcbnUc6iBqUnYb7ybCFE=
+h1:RFlx3KmvdwrchLzsgOfySoLPJ3vjn0jCOkxzKa3wL8U=
 20240118234246_initial.sql h1:dYuYBqns33WT+3p8VQvbKUP62k3k6w6h8S+FqNqgSvU=
 20240130122324_order_from_address.sql h1:mMVI2iBUd1roIYLUqu0d2jZ7+B6exppRN8qqn+aIHx4=
 20240202010744_fees_on_order.sql h1:P7ngxZKqDKefBM5vk6M3kbWeMPVwbZ4MZVcLBjEfS34=
@@ -52,3 +52,4 @@ h1:j3Xw40bQvqen66wzxvMN3gcAcbnUc6iBqUnYb7ybCFE=
 20250425202927_rate_slippage.sql h1:+I0bp1gHMyiZ+vTvbX+y14Xq/bFTKPmr4LeSUWddYgc=
 20250505033200_tzs_bank_institutions.sql h1:kQHdkewxxx63Z5dMQJYsq5LPL1SaeBv8hGv84fpsLCQ=
 20250505033210_ugx_bank_institutions.sql h1:8ex3xOuruqqPQJbcR9rUNpPDHU4n8Q3URvUIXQ6oDDE=
+20250510125049_order_metadata.sql h1:4/l64vbC/4ryctVMJxhVjL4bWDqC2F+00lDJRRQM62I=

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -107,6 +107,7 @@ var (
 		{Name: "institution", Type: field.TypeString},
 		{Name: "account_identifier", Type: field.TypeString},
 		{Name: "account_name", Type: field.TypeString},
+		{Name: "metadata", Type: field.TypeJSON, Nullable: true},
 		{Name: "owner_address", Type: field.TypeString, Unique: true},
 		{Name: "last_indexed_block", Type: field.TypeInt64, Nullable: true},
 		{Name: "tx_hash", Type: field.TypeString, Nullable: true, Size: 70},
@@ -120,7 +121,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "linked_addresses_sender_profiles_linked_address",
-				Columns:    []*schema.Column{LinkedAddressesColumns[11]},
+				Columns:    []*schema.Column{LinkedAddressesColumns[12]},
 				RefColumns: []*schema.Column{SenderProfilesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -167,6 +167,7 @@ var (
 		{Name: "account_identifier", Type: field.TypeString},
 		{Name: "account_name", Type: field.TypeString},
 		{Name: "memo", Type: field.TypeString, Nullable: true},
+		{Name: "metadata", Type: field.TypeJSON, Nullable: true},
 		{Name: "cancellation_count", Type: field.TypeInt, Default: 0},
 		{Name: "cancellation_reasons", Type: field.TypeJSON},
 		{Name: "provider_profile_assigned_orders", Type: field.TypeString, Nullable: true},
@@ -181,19 +182,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "lock_payment_orders_provider_profiles_assigned_orders",
-				Columns:    []*schema.Column{LockPaymentOrdersColumns[16]},
+				Columns:    []*schema.Column{LockPaymentOrdersColumns[17]},
 				RefColumns: []*schema.Column{ProviderProfilesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "lock_payment_orders_provision_buckets_lock_payment_orders",
-				Columns:    []*schema.Column{LockPaymentOrdersColumns[17]},
+				Columns:    []*schema.Column{LockPaymentOrdersColumns[18]},
 				RefColumns: []*schema.Column{ProvisionBucketsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "lock_payment_orders_tokens_lock_payment_orders",
-				Columns:    []*schema.Column{LockPaymentOrdersColumns[18]},
+				Columns:    []*schema.Column{LockPaymentOrdersColumns[19]},
 				RefColumns: []*schema.Column{TokensColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -202,7 +203,7 @@ var (
 			{
 				Name:    "lockpaymentorder_gateway_id_rate_tx_hash_block_number_institution_account_identifier_account_name_memo_token_lock_payment_orders",
 				Unique:  true,
-				Columns: []*schema.Column{LockPaymentOrdersColumns[3], LockPaymentOrdersColumns[5], LockPaymentOrdersColumns[7], LockPaymentOrdersColumns[9], LockPaymentOrdersColumns[10], LockPaymentOrdersColumns[11], LockPaymentOrdersColumns[12], LockPaymentOrdersColumns[13], LockPaymentOrdersColumns[18]},
+				Columns: []*schema.Column{LockPaymentOrdersColumns[3], LockPaymentOrdersColumns[5], LockPaymentOrdersColumns[7], LockPaymentOrdersColumns[9], LockPaymentOrdersColumns[10], LockPaymentOrdersColumns[11], LockPaymentOrdersColumns[12], LockPaymentOrdersColumns[13], LockPaymentOrdersColumns[19]},
 			},
 		},
 	}
@@ -295,6 +296,7 @@ var (
 		{Name: "account_name", Type: field.TypeString},
 		{Name: "memo", Type: field.TypeString, Nullable: true},
 		{Name: "provider_id", Type: field.TypeString, Nullable: true},
+		{Name: "metadata", Type: field.TypeJSON, Nullable: true},
 		{Name: "payment_order_recipient", Type: field.TypeUUID, Unique: true},
 	}
 	// PaymentOrderRecipientsTable holds the schema information for the "payment_order_recipients" table.
@@ -305,7 +307,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "payment_order_recipients_payment_orders_recipient",
-				Columns:    []*schema.Column{PaymentOrderRecipientsColumns[6]},
+				Columns:    []*schema.Column{PaymentOrderRecipientsColumns[7]},
 				RefColumns: []*schema.Column{PaymentOrdersColumns[0]},
 				OnDelete:   schema.Cascade,
 			},

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -4897,6 +4897,7 @@ type LockPaymentOrderMutation struct {
 	account_identifier         *string
 	account_name               *string
 	memo                       *string
+	metadata                   *map[string]interface{}
 	cancellation_count         *int
 	addcancellation_count      *int
 	cancellation_reasons       *[]string
@@ -5597,6 +5598,55 @@ func (m *LockPaymentOrderMutation) ResetMemo() {
 	delete(m.clearedFields, lockpaymentorder.FieldMemo)
 }
 
+// SetMetadata sets the "metadata" field.
+func (m *LockPaymentOrderMutation) SetMetadata(value map[string]interface{}) {
+	m.metadata = &value
+}
+
+// Metadata returns the value of the "metadata" field in the mutation.
+func (m *LockPaymentOrderMutation) Metadata() (r map[string]interface{}, exists bool) {
+	v := m.metadata
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldMetadata returns the old "metadata" field's value of the LockPaymentOrder entity.
+// If the LockPaymentOrder object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *LockPaymentOrderMutation) OldMetadata(ctx context.Context) (v map[string]interface{}, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldMetadata is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldMetadata requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldMetadata: %w", err)
+	}
+	return oldValue.Metadata, nil
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (m *LockPaymentOrderMutation) ClearMetadata() {
+	m.metadata = nil
+	m.clearedFields[lockpaymentorder.FieldMetadata] = struct{}{}
+}
+
+// MetadataCleared returns if the "metadata" field was cleared in this mutation.
+func (m *LockPaymentOrderMutation) MetadataCleared() bool {
+	_, ok := m.clearedFields[lockpaymentorder.FieldMetadata]
+	return ok
+}
+
+// ResetMetadata resets all changes to the "metadata" field.
+func (m *LockPaymentOrderMutation) ResetMetadata() {
+	m.metadata = nil
+	delete(m.clearedFields, lockpaymentorder.FieldMetadata)
+}
+
 // SetCancellationCount sets the "cancellation_count" field.
 func (m *LockPaymentOrderMutation) SetCancellationCount(i int) {
 	m.cancellation_count = &i
@@ -5963,7 +6013,7 @@ func (m *LockPaymentOrderMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *LockPaymentOrderMutation) Fields() []string {
-	fields := make([]string, 0, 15)
+	fields := make([]string, 0, 16)
 	if m.created_at != nil {
 		fields = append(fields, lockpaymentorder.FieldCreatedAt)
 	}
@@ -6002,6 +6052,9 @@ func (m *LockPaymentOrderMutation) Fields() []string {
 	}
 	if m.memo != nil {
 		fields = append(fields, lockpaymentorder.FieldMemo)
+	}
+	if m.metadata != nil {
+		fields = append(fields, lockpaymentorder.FieldMetadata)
 	}
 	if m.cancellation_count != nil {
 		fields = append(fields, lockpaymentorder.FieldCancellationCount)
@@ -6043,6 +6096,8 @@ func (m *LockPaymentOrderMutation) Field(name string) (ent.Value, bool) {
 		return m.AccountName()
 	case lockpaymentorder.FieldMemo:
 		return m.Memo()
+	case lockpaymentorder.FieldMetadata:
+		return m.Metadata()
 	case lockpaymentorder.FieldCancellationCount:
 		return m.CancellationCount()
 	case lockpaymentorder.FieldCancellationReasons:
@@ -6082,6 +6137,8 @@ func (m *LockPaymentOrderMutation) OldField(ctx context.Context, name string) (e
 		return m.OldAccountName(ctx)
 	case lockpaymentorder.FieldMemo:
 		return m.OldMemo(ctx)
+	case lockpaymentorder.FieldMetadata:
+		return m.OldMetadata(ctx)
 	case lockpaymentorder.FieldCancellationCount:
 		return m.OldCancellationCount(ctx)
 	case lockpaymentorder.FieldCancellationReasons:
@@ -6185,6 +6242,13 @@ func (m *LockPaymentOrderMutation) SetField(name string, value ent.Value) error 
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetMemo(v)
+		return nil
+	case lockpaymentorder.FieldMetadata:
+		v, ok := value.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetMetadata(v)
 		return nil
 	case lockpaymentorder.FieldCancellationCount:
 		v, ok := value.(int)
@@ -6299,6 +6363,9 @@ func (m *LockPaymentOrderMutation) ClearedFields() []string {
 	if m.FieldCleared(lockpaymentorder.FieldMemo) {
 		fields = append(fields, lockpaymentorder.FieldMemo)
 	}
+	if m.FieldCleared(lockpaymentorder.FieldMetadata) {
+		fields = append(fields, lockpaymentorder.FieldMetadata)
+	}
 	return fields
 }
 
@@ -6318,6 +6385,9 @@ func (m *LockPaymentOrderMutation) ClearField(name string) error {
 		return nil
 	case lockpaymentorder.FieldMemo:
 		m.ClearMemo()
+		return nil
+	case lockpaymentorder.FieldMetadata:
+		m.ClearMetadata()
 		return nil
 	}
 	return fmt.Errorf("unknown LockPaymentOrder nullable field %s", name)
@@ -6365,6 +6435,9 @@ func (m *LockPaymentOrderMutation) ResetField(name string) error {
 		return nil
 	case lockpaymentorder.FieldMemo:
 		m.ResetMemo()
+		return nil
+	case lockpaymentorder.FieldMetadata:
+		m.ResetMetadata()
 		return nil
 	case lockpaymentorder.FieldCancellationCount:
 		m.ResetCancellationCount()
@@ -9835,6 +9908,7 @@ type PaymentOrderRecipientMutation struct {
 	account_name         *string
 	memo                 *string
 	provider_id          *string
+	metadata             *map[string]interface{}
 	clearedFields        map[string]struct{}
 	payment_order        *uuid.UUID
 	clearedpayment_order bool
@@ -10147,6 +10221,55 @@ func (m *PaymentOrderRecipientMutation) ResetProviderID() {
 	delete(m.clearedFields, paymentorderrecipient.FieldProviderID)
 }
 
+// SetMetadata sets the "metadata" field.
+func (m *PaymentOrderRecipientMutation) SetMetadata(value map[string]interface{}) {
+	m.metadata = &value
+}
+
+// Metadata returns the value of the "metadata" field in the mutation.
+func (m *PaymentOrderRecipientMutation) Metadata() (r map[string]interface{}, exists bool) {
+	v := m.metadata
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldMetadata returns the old "metadata" field's value of the PaymentOrderRecipient entity.
+// If the PaymentOrderRecipient object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PaymentOrderRecipientMutation) OldMetadata(ctx context.Context) (v map[string]interface{}, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldMetadata is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldMetadata requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldMetadata: %w", err)
+	}
+	return oldValue.Metadata, nil
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (m *PaymentOrderRecipientMutation) ClearMetadata() {
+	m.metadata = nil
+	m.clearedFields[paymentorderrecipient.FieldMetadata] = struct{}{}
+}
+
+// MetadataCleared returns if the "metadata" field was cleared in this mutation.
+func (m *PaymentOrderRecipientMutation) MetadataCleared() bool {
+	_, ok := m.clearedFields[paymentorderrecipient.FieldMetadata]
+	return ok
+}
+
+// ResetMetadata resets all changes to the "metadata" field.
+func (m *PaymentOrderRecipientMutation) ResetMetadata() {
+	m.metadata = nil
+	delete(m.clearedFields, paymentorderrecipient.FieldMetadata)
+}
+
 // SetPaymentOrderID sets the "payment_order" edge to the PaymentOrder entity by id.
 func (m *PaymentOrderRecipientMutation) SetPaymentOrderID(id uuid.UUID) {
 	m.payment_order = &id
@@ -10220,7 +10343,7 @@ func (m *PaymentOrderRecipientMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PaymentOrderRecipientMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 6)
 	if m.institution != nil {
 		fields = append(fields, paymentorderrecipient.FieldInstitution)
 	}
@@ -10235,6 +10358,9 @@ func (m *PaymentOrderRecipientMutation) Fields() []string {
 	}
 	if m.provider_id != nil {
 		fields = append(fields, paymentorderrecipient.FieldProviderID)
+	}
+	if m.metadata != nil {
+		fields = append(fields, paymentorderrecipient.FieldMetadata)
 	}
 	return fields
 }
@@ -10254,6 +10380,8 @@ func (m *PaymentOrderRecipientMutation) Field(name string) (ent.Value, bool) {
 		return m.Memo()
 	case paymentorderrecipient.FieldProviderID:
 		return m.ProviderID()
+	case paymentorderrecipient.FieldMetadata:
+		return m.Metadata()
 	}
 	return nil, false
 }
@@ -10273,6 +10401,8 @@ func (m *PaymentOrderRecipientMutation) OldField(ctx context.Context, name strin
 		return m.OldMemo(ctx)
 	case paymentorderrecipient.FieldProviderID:
 		return m.OldProviderID(ctx)
+	case paymentorderrecipient.FieldMetadata:
+		return m.OldMetadata(ctx)
 	}
 	return nil, fmt.Errorf("unknown PaymentOrderRecipient field %s", name)
 }
@@ -10317,6 +10447,13 @@ func (m *PaymentOrderRecipientMutation) SetField(name string, value ent.Value) e
 		}
 		m.SetProviderID(v)
 		return nil
+	case paymentorderrecipient.FieldMetadata:
+		v, ok := value.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetMetadata(v)
+		return nil
 	}
 	return fmt.Errorf("unknown PaymentOrderRecipient field %s", name)
 }
@@ -10353,6 +10490,9 @@ func (m *PaymentOrderRecipientMutation) ClearedFields() []string {
 	if m.FieldCleared(paymentorderrecipient.FieldProviderID) {
 		fields = append(fields, paymentorderrecipient.FieldProviderID)
 	}
+	if m.FieldCleared(paymentorderrecipient.FieldMetadata) {
+		fields = append(fields, paymentorderrecipient.FieldMetadata)
+	}
 	return fields
 }
 
@@ -10372,6 +10512,9 @@ func (m *PaymentOrderRecipientMutation) ClearField(name string) error {
 		return nil
 	case paymentorderrecipient.FieldProviderID:
 		m.ClearProviderID()
+		return nil
+	case paymentorderrecipient.FieldMetadata:
+		m.ClearMetadata()
 		return nil
 	}
 	return fmt.Errorf("unknown PaymentOrderRecipient nullable field %s", name)
@@ -10395,6 +10538,9 @@ func (m *PaymentOrderRecipientMutation) ResetField(name string) error {
 		return nil
 	case paymentorderrecipient.FieldProviderID:
 		m.ResetProviderID()
+		return nil
+	case paymentorderrecipient.FieldMetadata:
+		m.ResetMetadata()
 		return nil
 	}
 	return fmt.Errorf("unknown PaymentOrderRecipient field %s", name)

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -3175,6 +3175,7 @@ type LinkedAddressMutation struct {
 	institution           *string
 	account_identifier    *string
 	account_name          *string
+	metadata              *map[string]interface{}
 	owner_address         *string
 	last_indexed_block    *int64
 	addlast_indexed_block *int64
@@ -3538,6 +3539,55 @@ func (m *LinkedAddressMutation) ResetAccountName() {
 	m.account_name = nil
 }
 
+// SetMetadata sets the "metadata" field.
+func (m *LinkedAddressMutation) SetMetadata(value map[string]interface{}) {
+	m.metadata = &value
+}
+
+// Metadata returns the value of the "metadata" field in the mutation.
+func (m *LinkedAddressMutation) Metadata() (r map[string]interface{}, exists bool) {
+	v := m.metadata
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldMetadata returns the old "metadata" field's value of the LinkedAddress entity.
+// If the LinkedAddress object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *LinkedAddressMutation) OldMetadata(ctx context.Context) (v map[string]interface{}, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldMetadata is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldMetadata requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldMetadata: %w", err)
+	}
+	return oldValue.Metadata, nil
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (m *LinkedAddressMutation) ClearMetadata() {
+	m.metadata = nil
+	m.clearedFields[linkedaddress.FieldMetadata] = struct{}{}
+}
+
+// MetadataCleared returns if the "metadata" field was cleared in this mutation.
+func (m *LinkedAddressMutation) MetadataCleared() bool {
+	_, ok := m.clearedFields[linkedaddress.FieldMetadata]
+	return ok
+}
+
+// ResetMetadata resets all changes to the "metadata" field.
+func (m *LinkedAddressMutation) ResetMetadata() {
+	m.metadata = nil
+	delete(m.clearedFields, linkedaddress.FieldMetadata)
+}
+
 // SetOwnerAddress sets the "owner_address" field.
 func (m *LinkedAddressMutation) SetOwnerAddress(s string) {
 	m.owner_address = &s
@@ -3781,7 +3831,7 @@ func (m *LinkedAddressMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *LinkedAddressMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.created_at != nil {
 		fields = append(fields, linkedaddress.FieldCreatedAt)
 	}
@@ -3802,6 +3852,9 @@ func (m *LinkedAddressMutation) Fields() []string {
 	}
 	if m.account_name != nil {
 		fields = append(fields, linkedaddress.FieldAccountName)
+	}
+	if m.metadata != nil {
+		fields = append(fields, linkedaddress.FieldMetadata)
 	}
 	if m.owner_address != nil {
 		fields = append(fields, linkedaddress.FieldOwnerAddress)
@@ -3834,6 +3887,8 @@ func (m *LinkedAddressMutation) Field(name string) (ent.Value, bool) {
 		return m.AccountIdentifier()
 	case linkedaddress.FieldAccountName:
 		return m.AccountName()
+	case linkedaddress.FieldMetadata:
+		return m.Metadata()
 	case linkedaddress.FieldOwnerAddress:
 		return m.OwnerAddress()
 	case linkedaddress.FieldLastIndexedBlock:
@@ -3863,6 +3918,8 @@ func (m *LinkedAddressMutation) OldField(ctx context.Context, name string) (ent.
 		return m.OldAccountIdentifier(ctx)
 	case linkedaddress.FieldAccountName:
 		return m.OldAccountName(ctx)
+	case linkedaddress.FieldMetadata:
+		return m.OldMetadata(ctx)
 	case linkedaddress.FieldOwnerAddress:
 		return m.OldOwnerAddress(ctx)
 	case linkedaddress.FieldLastIndexedBlock:
@@ -3926,6 +3983,13 @@ func (m *LinkedAddressMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetAccountName(v)
+		return nil
+	case linkedaddress.FieldMetadata:
+		v, ok := value.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetMetadata(v)
 		return nil
 	case linkedaddress.FieldOwnerAddress:
 		v, ok := value.(string)
@@ -3993,6 +4057,9 @@ func (m *LinkedAddressMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *LinkedAddressMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(linkedaddress.FieldMetadata) {
+		fields = append(fields, linkedaddress.FieldMetadata)
+	}
 	if m.FieldCleared(linkedaddress.FieldLastIndexedBlock) {
 		fields = append(fields, linkedaddress.FieldLastIndexedBlock)
 	}
@@ -4013,6 +4080,9 @@ func (m *LinkedAddressMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *LinkedAddressMutation) ClearField(name string) error {
 	switch name {
+	case linkedaddress.FieldMetadata:
+		m.ClearMetadata()
+		return nil
 	case linkedaddress.FieldLastIndexedBlock:
 		m.ClearLastIndexedBlock()
 		return nil
@@ -4047,6 +4117,9 @@ func (m *LinkedAddressMutation) ResetField(name string) error {
 		return nil
 	case linkedaddress.FieldAccountName:
 		m.ResetAccountName()
+		return nil
+	case linkedaddress.FieldMetadata:
+		m.ResetMetadata()
 		return nil
 	case linkedaddress.FieldOwnerAddress:
 		m.ResetOwnerAddress()

--- a/ent/paymentorderrecipient/paymentorderrecipient.go
+++ b/ent/paymentorderrecipient/paymentorderrecipient.go
@@ -22,6 +22,8 @@ const (
 	FieldMemo = "memo"
 	// FieldProviderID holds the string denoting the provider_id field in the database.
 	FieldProviderID = "provider_id"
+	// FieldMetadata holds the string denoting the metadata field in the database.
+	FieldMetadata = "metadata"
 	// EdgePaymentOrder holds the string denoting the payment_order edge name in mutations.
 	EdgePaymentOrder = "payment_order"
 	// Table holds the table name of the paymentorderrecipient in the database.
@@ -43,6 +45,7 @@ var Columns = []string{
 	FieldAccountName,
 	FieldMemo,
 	FieldProviderID,
+	FieldMetadata,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the "payment_order_recipients"

--- a/ent/paymentorderrecipient/where.go
+++ b/ent/paymentorderrecipient/where.go
@@ -423,6 +423,16 @@ func ProviderIDContainsFold(v string) predicate.PaymentOrderRecipient {
 	return predicate.PaymentOrderRecipient(sql.FieldContainsFold(FieldProviderID, v))
 }
 
+// MetadataIsNil applies the IsNil predicate on the "metadata" field.
+func MetadataIsNil() predicate.PaymentOrderRecipient {
+	return predicate.PaymentOrderRecipient(sql.FieldIsNull(FieldMetadata))
+}
+
+// MetadataNotNil applies the NotNil predicate on the "metadata" field.
+func MetadataNotNil() predicate.PaymentOrderRecipient {
+	return predicate.PaymentOrderRecipient(sql.FieldNotNull(FieldMetadata))
+}
+
 // HasPaymentOrder applies the HasEdge predicate on the "payment_order" edge.
 func HasPaymentOrder() predicate.PaymentOrderRecipient {
 	return predicate.PaymentOrderRecipient(func(s *sql.Selector) {

--- a/ent/paymentorderrecipient_create.go
+++ b/ent/paymentorderrecipient_create.go
@@ -69,6 +69,12 @@ func (porc *PaymentOrderRecipientCreate) SetNillableProviderID(s *string) *Payme
 	return porc
 }
 
+// SetMetadata sets the "metadata" field.
+func (porc *PaymentOrderRecipientCreate) SetMetadata(m map[string]interface{}) *PaymentOrderRecipientCreate {
+	porc.mutation.SetMetadata(m)
+	return porc
+}
+
 // SetPaymentOrderID sets the "payment_order" edge to the PaymentOrder entity by ID.
 func (porc *PaymentOrderRecipientCreate) SetPaymentOrderID(id uuid.UUID) *PaymentOrderRecipientCreate {
 	porc.mutation.SetPaymentOrderID(id)
@@ -172,6 +178,10 @@ func (porc *PaymentOrderRecipientCreate) createSpec() (*PaymentOrderRecipient, *
 	if value, ok := porc.mutation.ProviderID(); ok {
 		_spec.SetField(paymentorderrecipient.FieldProviderID, field.TypeString, value)
 		_node.ProviderID = value
+	}
+	if value, ok := porc.mutation.Metadata(); ok {
+		_spec.SetField(paymentorderrecipient.FieldMetadata, field.TypeJSON, value)
+		_node.Metadata = value
 	}
 	if nodes := porc.mutation.PaymentOrderIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -314,6 +324,24 @@ func (u *PaymentOrderRecipientUpsert) ClearProviderID() *PaymentOrderRecipientUp
 	return u
 }
 
+// SetMetadata sets the "metadata" field.
+func (u *PaymentOrderRecipientUpsert) SetMetadata(v map[string]interface{}) *PaymentOrderRecipientUpsert {
+	u.Set(paymentorderrecipient.FieldMetadata, v)
+	return u
+}
+
+// UpdateMetadata sets the "metadata" field to the value that was provided on create.
+func (u *PaymentOrderRecipientUpsert) UpdateMetadata() *PaymentOrderRecipientUpsert {
+	u.SetExcluded(paymentorderrecipient.FieldMetadata)
+	return u
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (u *PaymentOrderRecipientUpsert) ClearMetadata() *PaymentOrderRecipientUpsert {
+	u.SetNull(paymentorderrecipient.FieldMetadata)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -435,6 +463,27 @@ func (u *PaymentOrderRecipientUpsertOne) UpdateProviderID() *PaymentOrderRecipie
 func (u *PaymentOrderRecipientUpsertOne) ClearProviderID() *PaymentOrderRecipientUpsertOne {
 	return u.Update(func(s *PaymentOrderRecipientUpsert) {
 		s.ClearProviderID()
+	})
+}
+
+// SetMetadata sets the "metadata" field.
+func (u *PaymentOrderRecipientUpsertOne) SetMetadata(v map[string]interface{}) *PaymentOrderRecipientUpsertOne {
+	return u.Update(func(s *PaymentOrderRecipientUpsert) {
+		s.SetMetadata(v)
+	})
+}
+
+// UpdateMetadata sets the "metadata" field to the value that was provided on create.
+func (u *PaymentOrderRecipientUpsertOne) UpdateMetadata() *PaymentOrderRecipientUpsertOne {
+	return u.Update(func(s *PaymentOrderRecipientUpsert) {
+		s.UpdateMetadata()
+	})
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (u *PaymentOrderRecipientUpsertOne) ClearMetadata() *PaymentOrderRecipientUpsertOne {
+	return u.Update(func(s *PaymentOrderRecipientUpsert) {
+		s.ClearMetadata()
 	})
 }
 
@@ -722,6 +771,27 @@ func (u *PaymentOrderRecipientUpsertBulk) UpdateProviderID() *PaymentOrderRecipi
 func (u *PaymentOrderRecipientUpsertBulk) ClearProviderID() *PaymentOrderRecipientUpsertBulk {
 	return u.Update(func(s *PaymentOrderRecipientUpsert) {
 		s.ClearProviderID()
+	})
+}
+
+// SetMetadata sets the "metadata" field.
+func (u *PaymentOrderRecipientUpsertBulk) SetMetadata(v map[string]interface{}) *PaymentOrderRecipientUpsertBulk {
+	return u.Update(func(s *PaymentOrderRecipientUpsert) {
+		s.SetMetadata(v)
+	})
+}
+
+// UpdateMetadata sets the "metadata" field to the value that was provided on create.
+func (u *PaymentOrderRecipientUpsertBulk) UpdateMetadata() *PaymentOrderRecipientUpsertBulk {
+	return u.Update(func(s *PaymentOrderRecipientUpsert) {
+		s.UpdateMetadata()
+	})
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (u *PaymentOrderRecipientUpsertBulk) ClearMetadata() *PaymentOrderRecipientUpsertBulk {
+	return u.Update(func(s *PaymentOrderRecipientUpsert) {
+		s.ClearMetadata()
 	})
 }
 

--- a/ent/paymentorderrecipient_update.go
+++ b/ent/paymentorderrecipient_update.go
@@ -111,6 +111,18 @@ func (poru *PaymentOrderRecipientUpdate) ClearProviderID() *PaymentOrderRecipien
 	return poru
 }
 
+// SetMetadata sets the "metadata" field.
+func (poru *PaymentOrderRecipientUpdate) SetMetadata(m map[string]interface{}) *PaymentOrderRecipientUpdate {
+	poru.mutation.SetMetadata(m)
+	return poru
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (poru *PaymentOrderRecipientUpdate) ClearMetadata() *PaymentOrderRecipientUpdate {
+	poru.mutation.ClearMetadata()
+	return poru
+}
+
 // SetPaymentOrderID sets the "payment_order" edge to the PaymentOrder entity by ID.
 func (poru *PaymentOrderRecipientUpdate) SetPaymentOrderID(id uuid.UUID) *PaymentOrderRecipientUpdate {
 	poru.mutation.SetPaymentOrderID(id)
@@ -200,6 +212,12 @@ func (poru *PaymentOrderRecipientUpdate) sqlSave(ctx context.Context) (n int, er
 	}
 	if poru.mutation.ProviderIDCleared() {
 		_spec.ClearField(paymentorderrecipient.FieldProviderID, field.TypeString)
+	}
+	if value, ok := poru.mutation.Metadata(); ok {
+		_spec.SetField(paymentorderrecipient.FieldMetadata, field.TypeJSON, value)
+	}
+	if poru.mutation.MetadataCleared() {
+		_spec.ClearField(paymentorderrecipient.FieldMetadata, field.TypeJSON)
 	}
 	if poru.mutation.PaymentOrderCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -332,6 +350,18 @@ func (poruo *PaymentOrderRecipientUpdateOne) ClearProviderID() *PaymentOrderReci
 	return poruo
 }
 
+// SetMetadata sets the "metadata" field.
+func (poruo *PaymentOrderRecipientUpdateOne) SetMetadata(m map[string]interface{}) *PaymentOrderRecipientUpdateOne {
+	poruo.mutation.SetMetadata(m)
+	return poruo
+}
+
+// ClearMetadata clears the value of the "metadata" field.
+func (poruo *PaymentOrderRecipientUpdateOne) ClearMetadata() *PaymentOrderRecipientUpdateOne {
+	poruo.mutation.ClearMetadata()
+	return poruo
+}
+
 // SetPaymentOrderID sets the "payment_order" edge to the PaymentOrder entity by ID.
 func (poruo *PaymentOrderRecipientUpdateOne) SetPaymentOrderID(id uuid.UUID) *PaymentOrderRecipientUpdateOne {
 	poruo.mutation.SetPaymentOrderID(id)
@@ -451,6 +481,12 @@ func (poruo *PaymentOrderRecipientUpdateOne) sqlSave(ctx context.Context) (_node
 	}
 	if poruo.mutation.ProviderIDCleared() {
 		_spec.ClearField(paymentorderrecipient.FieldProviderID, field.TypeString)
+	}
+	if value, ok := poruo.mutation.Metadata(); ok {
+		_spec.SetField(paymentorderrecipient.FieldMetadata, field.TypeJSON, value)
+	}
+	if poruo.mutation.MetadataCleared() {
+		_spec.ClearField(paymentorderrecipient.FieldMetadata, field.TypeJSON)
 	}
 	if poruo.mutation.PaymentOrderCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/runtime/runtime.go
+++ b/ent/runtime/runtime.go
@@ -122,7 +122,7 @@ func init() {
 	// linkedaddress.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	linkedaddress.UpdateDefaultUpdatedAt = linkedaddressDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// linkedaddressDescTxHash is the schema descriptor for tx_hash field.
-	linkedaddressDescTxHash := linkedaddressFields[7].Descriptor()
+	linkedaddressDescTxHash := linkedaddressFields[8].Descriptor()
 	// linkedaddress.TxHashValidator is a validator for the "tx_hash" field. It is called by the builders before save.
 	linkedaddress.TxHashValidator = linkedaddressDescTxHash.Validators[0].(func(string) error)
 	lockorderfulfillmentMixin := schema.LockOrderFulfillment{}.Mixin()

--- a/ent/runtime/runtime.go
+++ b/ent/runtime/runtime.go
@@ -164,11 +164,11 @@ func init() {
 	// lockpaymentorder.TxHashValidator is a validator for the "tx_hash" field. It is called by the builders before save.
 	lockpaymentorder.TxHashValidator = lockpaymentorderDescTxHash.Validators[0].(func(string) error)
 	// lockpaymentorderDescCancellationCount is the schema descriptor for cancellation_count field.
-	lockpaymentorderDescCancellationCount := lockpaymentorderFields[12].Descriptor()
+	lockpaymentorderDescCancellationCount := lockpaymentorderFields[13].Descriptor()
 	// lockpaymentorder.DefaultCancellationCount holds the default value on creation for the cancellation_count field.
 	lockpaymentorder.DefaultCancellationCount = lockpaymentorderDescCancellationCount.Default.(int)
 	// lockpaymentorderDescCancellationReasons is the schema descriptor for cancellation_reasons field.
-	lockpaymentorderDescCancellationReasons := lockpaymentorderFields[13].Descriptor()
+	lockpaymentorderDescCancellationReasons := lockpaymentorderFields[14].Descriptor()
 	// lockpaymentorder.DefaultCancellationReasons holds the default value on creation for the cancellation_reasons field.
 	lockpaymentorder.DefaultCancellationReasons = lockpaymentorderDescCancellationReasons.Default.([]string)
 	// lockpaymentorderDescID is the schema descriptor for id field.

--- a/ent/schema/linkedaddress.go
+++ b/ent/schema/linkedaddress.go
@@ -30,6 +30,8 @@ func (LinkedAddress) Fields() []ent.Field {
 		field.String("institution"),
 		field.String("account_identifier"),
 		field.String("account_name"),
+		field.JSON("metadata", map[string]interface{}{}).
+			Optional(),
 		field.String("owner_address").
 			Unique(),
 		field.Int64("last_indexed_block").

--- a/ent/schema/lockpaymentorder.go
+++ b/ent/schema/lockpaymentorder.go
@@ -46,6 +46,8 @@ func (LockPaymentOrder) Fields() []ent.Field {
 		field.String("account_name"),
 		field.String("memo").
 			Optional(),
+		field.JSON("metadata", map[string]interface{}{}).
+			Optional(),
 		field.Int("cancellation_count").
 			Default(0),
 		field.Strings("cancellation_reasons").

--- a/ent/schema/paymentorderrecipient.go
+++ b/ent/schema/paymentorderrecipient.go
@@ -21,6 +21,8 @@ func (PaymentOrderRecipient) Fields() []ent.Field {
 			Optional(),
 		field.String("provider_id").
 			Optional(),
+		field.JSON("metadata", map[string]interface{}{}).
+			Optional(),
 	}
 }
 

--- a/go.sum
+++ b/go.sum
@@ -566,6 +566,8 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cast v1.5.1 h1:R+kOtfhWQE6TVQzY+4D7wJLBgkdVasCEFxSUBYBYIlA=
 github.com/spf13/cast v1.5.1/go.mod h1:b9PdjNptOpzXr7Rq1q9gJML/2cdGQAo69NKzQ10KN48=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=

--- a/services/indexer.go
+++ b/services/indexer.go
@@ -1101,6 +1101,7 @@ func (s *IndexerService) CreateLockPaymentOrder(ctx context.Context, client type
 		AccountName:       recipient.AccountName,
 		ProviderID:        recipient.ProviderID,
 		Memo:              recipient.Memo,
+		Metadata:          recipient.Metadata,
 		ProvisionBucket:   provisionBucket,
 	}
 
@@ -1220,8 +1221,9 @@ func (s *IndexerService) CreateLockPaymentOrder(ctx context.Context, client type
 							"Amount":          lockPaymentOrder.Amount,
 							"Rate":            lockPaymentOrder.Rate,
 							"Memo":            lockPaymentOrder.Memo,
-							"ProvisionBucket": lockPaymentOrder.ProvisionBucket,
+							"Metadata":        lockPaymentOrder.Metadata,
 							"ProviderID":      lockPaymentOrder.ProviderID,
+							"ProvisionBucket": lockPaymentOrder.ProvisionBucket,
 						}).
 					Save(ctx)
 				if err != nil {
@@ -1244,6 +1246,7 @@ func (s *IndexerService) CreateLockPaymentOrder(ctx context.Context, client type
 			SetAccountIdentifier(lockPaymentOrder.AccountIdentifier).
 			SetAccountName(lockPaymentOrder.AccountName).
 			SetMemo(lockPaymentOrder.Memo).
+			SetMetadata(lockPaymentOrder.Metadata).
 			SetProvisionBucket(lockPaymentOrder.ProvisionBucket)
 
 		if lockPaymentOrder.ProviderID != "" {
@@ -1313,6 +1316,7 @@ func (s *IndexerService) handleCancellation(ctx context.Context, client types.RP
 			SetAccountIdentifier(lockPaymentOrder.AccountIdentifier).
 			SetAccountName(lockPaymentOrder.AccountName).
 			SetMemo(lockPaymentOrder.Memo).
+			SetMetadata(lockPaymentOrder.Metadata).
 			SetProvisionBucket(lockPaymentOrder.ProvisionBucket).
 			SetCancellationCount(3).
 			SetCancellationReasons([]string{cancellationReason}).

--- a/services/indexer.go
+++ b/services/indexer.go
@@ -299,6 +299,7 @@ func (s *IndexerService) IndexERC20Transfer(ctx context.Context, client types.RP
 				SetInstitution(linkedAddress.Institution).
 				SetAccountIdentifier(linkedAddress.AccountIdentifier).
 				SetAccountName(linkedAddress.AccountName).
+				SetMetadata(linkedAddress.Metadata).
 				SetPaymentOrder(order).
 				Save(ctx)
 			if err != nil {

--- a/services/kyc/smile/index_test.go
+++ b/services/kyc/smile/index_test.go
@@ -119,25 +119,6 @@ func TestSmileIDService(t *testing.T) {
 			assert.Equal(t, identityverificationrequest.StatusPending, ivr.Status)
 		})
 
-		// Test: Invalid signature format
-		t.Run("Invalid signature format", func(t *testing.T) {
-			// Clear any existing verification requests
-			_, err := client.IdentityVerificationRequest.Delete().Exec(context.Background())
-			require.NoError(t, err)
-
-			payload := types.VerificationRequest{
-				WalletAddress: "0x96216849c49358B10257cb55b28eA603c874b05E",
-				Signature:     "invalid_signature",
-				Nonce:         "test_nonce",
-			}
-
-			resp, err := service.RequestVerification(context.Background(), payload)
-
-			assert.Error(t, err)
-			assert.Nil(t, resp)
-			assert.Contains(t, err.Error(), "invalid signature: signature is not in the correct format")
-		})
-
 		// Test: Already verified wallet
 		t.Run("Already verified wallet", func(t *testing.T) {
 			// Clear any existing verification requests

--- a/services/kyc/smile/index_test.go
+++ b/services/kyc/smile/index_test.go
@@ -72,7 +72,7 @@ func TestSmileIDService(t *testing.T) {
 			SmileIdentityApiKey:    "test_api_key",
 		},
 		serverConf: &config.ServerConfiguration{
-			HostDomain: "https://api.example.com",
+			ServerURL: "https://api.example.com",
 		},
 		db: client,
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -416,6 +416,7 @@ type PaymentOrderRecipient struct {
 	ProviderID        string                 `json:"providerId"`
 	Metadata          map[string]interface{} `json:"metadata"`
 	Currency          string                 `json:"currency"`
+	Nonce             string                 `json:"nonce"`
 }
 
 // NewPaymentOrderPayload is the payload for the create payment order endpoint

--- a/types/types.go
+++ b/types/types.go
@@ -344,6 +344,7 @@ type LockPaymentOrderFields struct {
 	AccountName       string
 	ProviderID        string
 	Memo              string
+	Metadata          map[string]interface{}
 	ProvisionBucket   *ent.ProvisionBucket
 	UpdatedAt         time.Time
 	CreatedAt         time.Time
@@ -408,13 +409,13 @@ type LockPaymentOrderStatusResponse struct {
 
 // PaymentOrderRecipient describes a payment order recipient
 type PaymentOrderRecipient struct {
-	Institution       string `json:"institution" binding:"required"`
-	AccountIdentifier string `json:"accountIdentifier" binding:"required"`
-	AccountName       string `json:"accountName" binding:"required"`
-	Memo              string `json:"memo" binding:"required"`
-	ProviderID        string `json:"providerId"`
-	Currency          string `json:"currency"`
-	Nonce             string `json:"nonce"`
+	Institution       string                 `json:"institution" binding:"required"`
+	AccountIdentifier string                 `json:"accountIdentifier" binding:"required"`
+	AccountName       string                 `json:"accountName" binding:"required"`
+	Memo              string                 `json:"memo" binding:"required"`
+	ProviderID        string                 `json:"providerId"`
+	Metadata          map[string]interface{} `json:"metadata"`
+	Currency          string                 `json:"currency"`
 }
 
 // NewPaymentOrderPayload is the payload for the create payment order endpoint


### PR DESCRIPTION
### Description

This PR introduces a metadata field to payment orders and recipients to allow storing additional flexible data. The changes include:

1. Added a `metadata` field to both `LockPaymentOrder` and `PaymentOrderRecipient` models
   - Uses JSONB type for flexibility in storing various data structures
   - Field is optional to maintain backward compatibility
   - Metadata is included in the encrypted message for secure transmission

2. Refactored encryption logic
   - Moved `encryptOrderRecipient` function from `evm.go` and `tron.go` to `utils/crypto/crypto.go`
   - Updated both EVM and Tron implementations to use the centralized function
   - Added metadata to the encrypted message structure for complete data preservation

3. Configuration updates
   - Renamed `HostDomain` to `ServerURL` in server configuration for better clarity
   - Updated related references in KYC service

4. Database changes
   - Added new migration for metadata fields
   - Updated schema definitions and related code

### Testing

The changes can be tested by:

1. Running the database migrations:
   ```bash
   go run cmd/migrate/main.go
   ```

2. Creating a new payment order with metadata:
   ```json
   {
     "recipient": {
       "institution": "test_bank",
       "accountIdentifier": "1234567890",
       "accountName": "Test User",
       "memo": "Test memo",
       "metadata": {
         "customField": "value",
         "additionalInfo": {
           "key": "value"
         }
       }
     }
   }
   ```

3. Verifying the metadata is:
   - Stored correctly in the database
   - Included in the encrypted message
   - Preserved throughout the order lifecycle

Environment:
- Go 1.21
- PostgreSQL 15
- macOS 22.5.0

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`