### PR TITLE
fix soft delete for payment orders

### DIFF
--- a/ent/client.go
+++ b/ent/client.go
@@ -1532,12 +1532,14 @@ func (c *LockPaymentOrderClient) QueryTransactions(lpo *LockPaymentOrder) *Trans
 
 // Hooks returns the client hooks.
 func (c *LockPaymentOrderClient) Hooks() []Hook {
-	return c.hooks.LockPaymentOrder
+	hooks := c.hooks.LockPaymentOrder
+	return append(hooks[:len(hooks):len(hooks)], lockpaymentorder.Hooks[:]...)
 }
 
 // Interceptors returns the client interceptors.
 func (c *LockPaymentOrderClient) Interceptors() []Interceptor {
-	return c.inters.LockPaymentOrder
+	inters := c.inters.LockPaymentOrder
+	return append(inters[:len(inters):len(inters)], lockpaymentorder.Interceptors[:]...)
 }
 
 func (c *LockPaymentOrderClient) mutate(ctx context.Context, m *LockPaymentOrderMutation) (Value, error) {
@@ -1910,12 +1912,14 @@ func (c *PaymentOrderClient) QueryTransactions(po *PaymentOrder) *TransactionLog
 
 // Hooks returns the client hooks.
 func (c *PaymentOrderClient) Hooks() []Hook {
-	return c.hooks.PaymentOrder
+	hooks := c.hooks.PaymentOrder
+	return append(hooks[:len(hooks):len(hooks)], paymentorder.Hooks[:]...)
 }
 
 // Interceptors returns the client interceptors.
 func (c *PaymentOrderClient) Interceptors() []Interceptor {
-	return c.inters.PaymentOrder
+	inters := c.inters.PaymentOrder
+	return append(inters[:len(inters):len(inters)], paymentorder.Interceptors[:]...)
 }
 
 func (c *PaymentOrderClient) mutate(ctx context.Context, m *PaymentOrderMutation) (Value, error) {

--- a/ent/lockpaymentorder.go
+++ b/ent/lockpaymentorder.go
@@ -27,6 +27,8 @@ type LockPaymentOrder struct {
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	// DeletedAt holds the value of the "deleted_at" field.
+	DeletedAt time.Time `json:"deleted_at,omitempty"`
 	// GatewayID holds the value of the "gateway_id" field.
 	GatewayID string `json:"gateway_id,omitempty"`
 	// Amount holds the value of the "amount" field.
@@ -145,7 +147,7 @@ func (*LockPaymentOrder) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullInt64)
 		case lockpaymentorder.FieldGatewayID, lockpaymentorder.FieldTxHash, lockpaymentorder.FieldStatus, lockpaymentorder.FieldInstitution, lockpaymentorder.FieldAccountIdentifier, lockpaymentorder.FieldAccountName, lockpaymentorder.FieldMemo:
 			values[i] = new(sql.NullString)
-		case lockpaymentorder.FieldCreatedAt, lockpaymentorder.FieldUpdatedAt:
+		case lockpaymentorder.FieldCreatedAt, lockpaymentorder.FieldUpdatedAt, lockpaymentorder.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
 		case lockpaymentorder.FieldID:
 			values[i] = new(uuid.UUID)
@@ -187,6 +189,12 @@ func (lpo *LockPaymentOrder) assignValues(columns []string, values []any) error 
 				return fmt.Errorf("unexpected type %T for field updated_at", values[i])
 			} else if value.Valid {
 				lpo.UpdatedAt = value.Time
+			}
+		case lockpaymentorder.FieldDeletedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_at", values[i])
+			} else if value.Valid {
+				lpo.DeletedAt = value.Time
 			}
 		case lockpaymentorder.FieldGatewayID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -363,6 +371,9 @@ func (lpo *LockPaymentOrder) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("updated_at=")
 	builder.WriteString(lpo.UpdatedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("deleted_at=")
+	builder.WriteString(lpo.DeletedAt.Format(time.ANSIC))
 	builder.WriteString(", ")
 	builder.WriteString("gateway_id=")
 	builder.WriteString(lpo.GatewayID)

--- a/ent/lockpaymentorder/lockpaymentorder.go
+++ b/ent/lockpaymentorder/lockpaymentorder.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"github.com/google/uuid"
@@ -20,6 +21,8 @@ const (
 	FieldCreatedAt = "created_at"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
 	FieldUpdatedAt = "updated_at"
+	// FieldDeletedAt holds the string denoting the deleted_at field in the database.
+	FieldDeletedAt = "deleted_at"
 	// FieldGatewayID holds the string denoting the gateway_id field in the database.
 	FieldGatewayID = "gateway_id"
 	// FieldAmount holds the string denoting the amount field in the database.
@@ -102,6 +105,7 @@ var Columns = []string{
 	FieldID,
 	FieldCreatedAt,
 	FieldUpdatedAt,
+	FieldDeletedAt,
 	FieldGatewayID,
 	FieldAmount,
 	FieldRate,
@@ -141,7 +145,14 @@ func ValidColumn(column string) bool {
 	return false
 }
 
+// Note that the variables below are initialized by the runtime
+// package on the initialization of the application. Therefore,
+// it should be imported in the main as follows:
+//
+//	import _ "github.com/paycrest/aggregator/ent/runtime"
 var (
+	Hooks        [1]ent.Hook
+	Interceptors [1]ent.Interceptor
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -205,6 +216,11 @@ func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByUpdatedAt orders the results by the updated_at field.
 func ByUpdatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUpdatedAt, opts...).ToFunc()
+}
+
+// ByDeletedAt orders the results by the deleted_at field.
+func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
 }
 
 // ByGatewayID orders the results by the gateway_id field.

--- a/ent/lockpaymentorder/where.go
+++ b/ent/lockpaymentorder/where.go
@@ -67,6 +67,11 @@ func UpdatedAt(v time.Time) predicate.LockPaymentOrder {
 	return predicate.LockPaymentOrder(sql.FieldEQ(FieldUpdatedAt, v))
 }
 
+// DeletedAt applies equality check predicate on the "deleted_at" field. It's identical to DeletedAtEQ.
+func DeletedAt(v time.Time) predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldEQ(FieldDeletedAt, v))
+}
+
 // GatewayID applies equality check predicate on the "gateway_id" field. It's identical to GatewayIDEQ.
 func GatewayID(v string) predicate.LockPaymentOrder {
 	return predicate.LockPaymentOrder(sql.FieldEQ(FieldGatewayID, v))
@@ -200,6 +205,56 @@ func UpdatedAtLT(v time.Time) predicate.LockPaymentOrder {
 // UpdatedAtLTE applies the LTE predicate on the "updated_at" field.
 func UpdatedAtLTE(v time.Time) predicate.LockPaymentOrder {
 	return predicate.LockPaymentOrder(sql.FieldLTE(FieldUpdatedAt, v))
+}
+
+// DeletedAtEQ applies the EQ predicate on the "deleted_at" field.
+func DeletedAtEQ(v time.Time) predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtNEQ applies the NEQ predicate on the "deleted_at" field.
+func DeletedAtNEQ(v time.Time) predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldNEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtIn applies the In predicate on the "deleted_at" field.
+func DeletedAtIn(vs ...time.Time) predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtNotIn applies the NotIn predicate on the "deleted_at" field.
+func DeletedAtNotIn(vs ...time.Time) predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldNotIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtGT applies the GT predicate on the "deleted_at" field.
+func DeletedAtGT(v time.Time) predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldGT(FieldDeletedAt, v))
+}
+
+// DeletedAtGTE applies the GTE predicate on the "deleted_at" field.
+func DeletedAtGTE(v time.Time) predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldGTE(FieldDeletedAt, v))
+}
+
+// DeletedAtLT applies the LT predicate on the "deleted_at" field.
+func DeletedAtLT(v time.Time) predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldLT(FieldDeletedAt, v))
+}
+
+// DeletedAtLTE applies the LTE predicate on the "deleted_at" field.
+func DeletedAtLTE(v time.Time) predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldLTE(FieldDeletedAt, v))
+}
+
+// DeletedAtIsNil applies the IsNil predicate on the "deleted_at" field.
+func DeletedAtIsNil() predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldIsNull(FieldDeletedAt))
+}
+
+// DeletedAtNotNil applies the NotNil predicate on the "deleted_at" field.
+func DeletedAtNotNil() predicate.LockPaymentOrder {
+	return predicate.LockPaymentOrder(sql.FieldNotNull(FieldDeletedAt))
 }
 
 // GatewayIDEQ applies the EQ predicate on the "gateway_id" field.

--- a/ent/lockpaymentorder_create.go
+++ b/ent/lockpaymentorder_create.go
@@ -58,6 +58,20 @@ func (lpoc *LockPaymentOrderCreate) SetNillableUpdatedAt(t *time.Time) *LockPaym
 	return lpoc
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (lpoc *LockPaymentOrderCreate) SetDeletedAt(t time.Time) *LockPaymentOrderCreate {
+	lpoc.mutation.SetDeletedAt(t)
+	return lpoc
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (lpoc *LockPaymentOrderCreate) SetNillableDeletedAt(t *time.Time) *LockPaymentOrderCreate {
+	if t != nil {
+		lpoc.SetDeletedAt(*t)
+	}
+	return lpoc
+}
+
 // SetGatewayID sets the "gateway_id" field.
 func (lpoc *LockPaymentOrderCreate) SetGatewayID(s string) *LockPaymentOrderCreate {
 	lpoc.mutation.SetGatewayID(s)
@@ -274,7 +288,9 @@ func (lpoc *LockPaymentOrderCreate) Mutation() *LockPaymentOrderMutation {
 
 // Save creates the LockPaymentOrder in the database.
 func (lpoc *LockPaymentOrderCreate) Save(ctx context.Context) (*LockPaymentOrder, error) {
-	lpoc.defaults()
+	if err := lpoc.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, lpoc.sqlSave, lpoc.mutation, lpoc.hooks)
 }
 
@@ -301,12 +317,18 @@ func (lpoc *LockPaymentOrderCreate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (lpoc *LockPaymentOrderCreate) defaults() {
+func (lpoc *LockPaymentOrderCreate) defaults() error {
 	if _, ok := lpoc.mutation.CreatedAt(); !ok {
+		if lockpaymentorder.DefaultCreatedAt == nil {
+			return fmt.Errorf("ent: uninitialized lockpaymentorder.DefaultCreatedAt (forgotten import ent/runtime?)")
+		}
 		v := lockpaymentorder.DefaultCreatedAt()
 		lpoc.mutation.SetCreatedAt(v)
 	}
 	if _, ok := lpoc.mutation.UpdatedAt(); !ok {
+		if lockpaymentorder.DefaultUpdatedAt == nil {
+			return fmt.Errorf("ent: uninitialized lockpaymentorder.DefaultUpdatedAt (forgotten import ent/runtime?)")
+		}
 		v := lockpaymentorder.DefaultUpdatedAt()
 		lpoc.mutation.SetUpdatedAt(v)
 	}
@@ -323,9 +345,13 @@ func (lpoc *LockPaymentOrderCreate) defaults() {
 		lpoc.mutation.SetCancellationReasons(v)
 	}
 	if _, ok := lpoc.mutation.ID(); !ok {
+		if lockpaymentorder.DefaultID == nil {
+			return fmt.Errorf("ent: uninitialized lockpaymentorder.DefaultID (forgotten import ent/runtime?)")
+		}
 		v := lockpaymentorder.DefaultID()
 		lpoc.mutation.SetID(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -425,6 +451,10 @@ func (lpoc *LockPaymentOrderCreate) createSpec() (*LockPaymentOrder, *sqlgraph.C
 	if value, ok := lpoc.mutation.UpdatedAt(); ok {
 		_spec.SetField(lockpaymentorder.FieldUpdatedAt, field.TypeTime, value)
 		_node.UpdatedAt = value
+	}
+	if value, ok := lpoc.mutation.DeletedAt(); ok {
+		_spec.SetField(lockpaymentorder.FieldDeletedAt, field.TypeTime, value)
+		_node.DeletedAt = value
 	}
 	if value, ok := lpoc.mutation.GatewayID(); ok {
 		_spec.SetField(lockpaymentorder.FieldGatewayID, field.TypeString, value)
@@ -626,6 +656,24 @@ func (u *LockPaymentOrderUpsert) SetUpdatedAt(v time.Time) *LockPaymentOrderUpse
 // UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
 func (u *LockPaymentOrderUpsert) UpdateUpdatedAt() *LockPaymentOrderUpsert {
 	u.SetExcluded(lockpaymentorder.FieldUpdatedAt)
+	return u
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (u *LockPaymentOrderUpsert) SetDeletedAt(v time.Time) *LockPaymentOrderUpsert {
+	u.Set(lockpaymentorder.FieldDeletedAt, v)
+	return u
+}
+
+// UpdateDeletedAt sets the "deleted_at" field to the value that was provided on create.
+func (u *LockPaymentOrderUpsert) UpdateDeletedAt() *LockPaymentOrderUpsert {
+	u.SetExcluded(lockpaymentorder.FieldDeletedAt)
+	return u
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (u *LockPaymentOrderUpsert) ClearDeletedAt() *LockPaymentOrderUpsert {
+	u.SetNull(lockpaymentorder.FieldDeletedAt)
 	return u
 }
 
@@ -907,6 +955,27 @@ func (u *LockPaymentOrderUpsertOne) SetUpdatedAt(v time.Time) *LockPaymentOrderU
 func (u *LockPaymentOrderUpsertOne) UpdateUpdatedAt() *LockPaymentOrderUpsertOne {
 	return u.Update(func(s *LockPaymentOrderUpsert) {
 		s.UpdateUpdatedAt()
+	})
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (u *LockPaymentOrderUpsertOne) SetDeletedAt(v time.Time) *LockPaymentOrderUpsertOne {
+	return u.Update(func(s *LockPaymentOrderUpsert) {
+		s.SetDeletedAt(v)
+	})
+}
+
+// UpdateDeletedAt sets the "deleted_at" field to the value that was provided on create.
+func (u *LockPaymentOrderUpsertOne) UpdateDeletedAt() *LockPaymentOrderUpsertOne {
+	return u.Update(func(s *LockPaymentOrderUpsert) {
+		s.UpdateDeletedAt()
+	})
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (u *LockPaymentOrderUpsertOne) ClearDeletedAt() *LockPaymentOrderUpsertOne {
+	return u.Update(func(s *LockPaymentOrderUpsert) {
+		s.ClearDeletedAt()
 	})
 }
 
@@ -1391,6 +1460,27 @@ func (u *LockPaymentOrderUpsertBulk) SetUpdatedAt(v time.Time) *LockPaymentOrder
 func (u *LockPaymentOrderUpsertBulk) UpdateUpdatedAt() *LockPaymentOrderUpsertBulk {
 	return u.Update(func(s *LockPaymentOrderUpsert) {
 		s.UpdateUpdatedAt()
+	})
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (u *LockPaymentOrderUpsertBulk) SetDeletedAt(v time.Time) *LockPaymentOrderUpsertBulk {
+	return u.Update(func(s *LockPaymentOrderUpsert) {
+		s.SetDeletedAt(v)
+	})
+}
+
+// UpdateDeletedAt sets the "deleted_at" field to the value that was provided on create.
+func (u *LockPaymentOrderUpsertBulk) UpdateDeletedAt() *LockPaymentOrderUpsertBulk {
+	return u.Update(func(s *LockPaymentOrderUpsert) {
+		s.UpdateDeletedAt()
+	})
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (u *LockPaymentOrderUpsertBulk) ClearDeletedAt() *LockPaymentOrderUpsertBulk {
+	return u.Update(func(s *LockPaymentOrderUpsert) {
+		s.ClearDeletedAt()
 	})
 }
 

--- a/ent/lockpaymentorder_update.go
+++ b/ent/lockpaymentorder_update.go
@@ -42,6 +42,26 @@ func (lpou *LockPaymentOrderUpdate) SetUpdatedAt(t time.Time) *LockPaymentOrderU
 	return lpou
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (lpou *LockPaymentOrderUpdate) SetDeletedAt(t time.Time) *LockPaymentOrderUpdate {
+	lpou.mutation.SetDeletedAt(t)
+	return lpou
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (lpou *LockPaymentOrderUpdate) SetNillableDeletedAt(t *time.Time) *LockPaymentOrderUpdate {
+	if t != nil {
+		lpou.SetDeletedAt(*t)
+	}
+	return lpou
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (lpou *LockPaymentOrderUpdate) ClearDeletedAt() *LockPaymentOrderUpdate {
+	lpou.mutation.ClearDeletedAt()
+	return lpou
+}
+
 // SetGatewayID sets the "gateway_id" field.
 func (lpou *LockPaymentOrderUpdate) SetGatewayID(s string) *LockPaymentOrderUpdate {
 	lpou.mutation.SetGatewayID(s)
@@ -427,7 +447,9 @@ func (lpou *LockPaymentOrderUpdate) RemoveTransactions(t ...*TransactionLog) *Lo
 
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (lpou *LockPaymentOrderUpdate) Save(ctx context.Context) (int, error) {
-	lpou.defaults()
+	if err := lpou.defaults(); err != nil {
+		return 0, err
+	}
 	return withHooks(ctx, lpou.sqlSave, lpou.mutation, lpou.hooks)
 }
 
@@ -454,11 +476,15 @@ func (lpou *LockPaymentOrderUpdate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (lpou *LockPaymentOrderUpdate) defaults() {
+func (lpou *LockPaymentOrderUpdate) defaults() error {
 	if _, ok := lpou.mutation.UpdatedAt(); !ok {
+		if lockpaymentorder.UpdateDefaultUpdatedAt == nil {
+			return fmt.Errorf("ent: uninitialized lockpaymentorder.UpdateDefaultUpdatedAt (forgotten import ent/runtime?)")
+		}
 		v := lockpaymentorder.UpdateDefaultUpdatedAt()
 		lpou.mutation.SetUpdatedAt(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -493,6 +519,12 @@ func (lpou *LockPaymentOrderUpdate) sqlSave(ctx context.Context) (n int, err err
 	}
 	if value, ok := lpou.mutation.UpdatedAt(); ok {
 		_spec.SetField(lockpaymentorder.FieldUpdatedAt, field.TypeTime, value)
+	}
+	if value, ok := lpou.mutation.DeletedAt(); ok {
+		_spec.SetField(lockpaymentorder.FieldDeletedAt, field.TypeTime, value)
+	}
+	if lpou.mutation.DeletedAtCleared() {
+		_spec.ClearField(lockpaymentorder.FieldDeletedAt, field.TypeTime)
 	}
 	if value, ok := lpou.mutation.GatewayID(); ok {
 		_spec.SetField(lockpaymentorder.FieldGatewayID, field.TypeString, value)
@@ -765,6 +797,26 @@ type LockPaymentOrderUpdateOne struct {
 // SetUpdatedAt sets the "updated_at" field.
 func (lpouo *LockPaymentOrderUpdateOne) SetUpdatedAt(t time.Time) *LockPaymentOrderUpdateOne {
 	lpouo.mutation.SetUpdatedAt(t)
+	return lpouo
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (lpouo *LockPaymentOrderUpdateOne) SetDeletedAt(t time.Time) *LockPaymentOrderUpdateOne {
+	lpouo.mutation.SetDeletedAt(t)
+	return lpouo
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (lpouo *LockPaymentOrderUpdateOne) SetNillableDeletedAt(t *time.Time) *LockPaymentOrderUpdateOne {
+	if t != nil {
+		lpouo.SetDeletedAt(*t)
+	}
+	return lpouo
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (lpouo *LockPaymentOrderUpdateOne) ClearDeletedAt() *LockPaymentOrderUpdateOne {
+	lpouo.mutation.ClearDeletedAt()
 	return lpouo
 }
 
@@ -1166,7 +1218,9 @@ func (lpouo *LockPaymentOrderUpdateOne) Select(field string, fields ...string) *
 
 // Save executes the query and returns the updated LockPaymentOrder entity.
 func (lpouo *LockPaymentOrderUpdateOne) Save(ctx context.Context) (*LockPaymentOrder, error) {
-	lpouo.defaults()
+	if err := lpouo.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, lpouo.sqlSave, lpouo.mutation, lpouo.hooks)
 }
 
@@ -1193,11 +1247,15 @@ func (lpouo *LockPaymentOrderUpdateOne) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (lpouo *LockPaymentOrderUpdateOne) defaults() {
+func (lpouo *LockPaymentOrderUpdateOne) defaults() error {
 	if _, ok := lpouo.mutation.UpdatedAt(); !ok {
+		if lockpaymentorder.UpdateDefaultUpdatedAt == nil {
+			return fmt.Errorf("ent: uninitialized lockpaymentorder.UpdateDefaultUpdatedAt (forgotten import ent/runtime?)")
+		}
 		v := lockpaymentorder.UpdateDefaultUpdatedAt()
 		lpouo.mutation.SetUpdatedAt(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -1249,6 +1307,12 @@ func (lpouo *LockPaymentOrderUpdateOne) sqlSave(ctx context.Context) (_node *Loc
 	}
 	if value, ok := lpouo.mutation.UpdatedAt(); ok {
 		_spec.SetField(lockpaymentorder.FieldUpdatedAt, field.TypeTime, value)
+	}
+	if value, ok := lpouo.mutation.DeletedAt(); ok {
+		_spec.SetField(lockpaymentorder.FieldDeletedAt, field.TypeTime, value)
+	}
+	if lpouo.mutation.DeletedAtCleared() {
+		_spec.ClearField(lockpaymentorder.FieldDeletedAt, field.TypeTime)
 	}
 	if value, ok := lpouo.mutation.GatewayID(); ok {
 		_spec.SetField(lockpaymentorder.FieldGatewayID, field.TypeString, value)

--- a/ent/migrate/migrations/20250513080615_add_soft_delete_field.sql
+++ b/ent/migrate/migrations/20250513080615_add_soft_delete_field.sql
@@ -1,0 +1,4 @@
+-- Modify "lock_payment_orders" table
+ALTER TABLE "public"."lock_payment_orders" ADD COLUMN "deleted_at" timestamptz NULL;
+-- Modify "payment_orders" table
+ALTER TABLE "public"."payment_orders" DROP CONSTRAINT "payment_orders_sender_profiles_payment_orders", ADD COLUMN "deleted_at" timestamptz NULL, ADD CONSTRAINT "payment_orders_sender_profiles_payment_orders" FOREIGN KEY ("sender_profile_payment_orders") REFERENCES "public"."sender_profiles" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;

--- a/ent/migrate/migrations/atlas.sum
+++ b/ent/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:mbjYUn+9Ft6WqrWeZurNpG+pt3iyhucaGjJHe2+C+uI=
+h1:tIykc/fDN8OkBvdprfMA3tb28+GElxkOKZqgcBv5r3g=
 20240118234246_initial.sql h1:dYuYBqns33WT+3p8VQvbKUP62k3k6w6h8S+FqNqgSvU=
 20240130122324_order_from_address.sql h1:mMVI2iBUd1roIYLUqu0d2jZ7+B6exppRN8qqn+aIHx4=
 20240202010744_fees_on_order.sql h1:P7ngxZKqDKefBM5vk6M3kbWeMPVwbZ4MZVcLBjEfS34=
@@ -53,3 +53,4 @@ h1:mbjYUn+9Ft6WqrWeZurNpG+pt3iyhucaGjJHe2+C+uI=
 20250505033200_tzs_bank_institutions.sql h1:kQHdkewxxx63Z5dMQJYsq5LPL1SaeBv8hGv84fpsLCQ=
 20250505033210_ugx_bank_institutions.sql h1:8ex3xOuruqqPQJbcR9rUNpPDHU4n8Q3URvUIXQ6oDDE=
 20250510231545_order_metadata.sql h1:BrHlYt3LvuYcnsw7b9xfzjg5U4D1RfPy+RusxRDj66k=
+20250513080615_add_soft_delete_field.sql h1:lbMDQfeYQHxBonc62BisAmVdzf/xqQkbHSCOBCUBk0s=

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -157,6 +157,7 @@ var (
 		{Name: "id", Type: field.TypeUUID},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
+		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "gateway_id", Type: field.TypeString},
 		{Name: "amount", Type: field.TypeFloat64},
 		{Name: "rate", Type: field.TypeFloat64},
@@ -183,19 +184,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "lock_payment_orders_provider_profiles_assigned_orders",
-				Columns:    []*schema.Column{LockPaymentOrdersColumns[17]},
+				Columns:    []*schema.Column{LockPaymentOrdersColumns[18]},
 				RefColumns: []*schema.Column{ProviderProfilesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "lock_payment_orders_provision_buckets_lock_payment_orders",
-				Columns:    []*schema.Column{LockPaymentOrdersColumns[18]},
+				Columns:    []*schema.Column{LockPaymentOrdersColumns[19]},
 				RefColumns: []*schema.Column{ProvisionBucketsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "lock_payment_orders_tokens_lock_payment_orders",
-				Columns:    []*schema.Column{LockPaymentOrdersColumns[19]},
+				Columns:    []*schema.Column{LockPaymentOrdersColumns[20]},
 				RefColumns: []*schema.Column{TokensColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -204,7 +205,7 @@ var (
 			{
 				Name:    "lockpaymentorder_gateway_id_rate_tx_hash_block_number_institution_account_identifier_account_name_memo_token_lock_payment_orders",
 				Unique:  true,
-				Columns: []*schema.Column{LockPaymentOrdersColumns[3], LockPaymentOrdersColumns[5], LockPaymentOrdersColumns[7], LockPaymentOrdersColumns[9], LockPaymentOrdersColumns[10], LockPaymentOrdersColumns[11], LockPaymentOrdersColumns[12], LockPaymentOrdersColumns[13], LockPaymentOrdersColumns[19]},
+				Columns: []*schema.Column{LockPaymentOrdersColumns[4], LockPaymentOrdersColumns[6], LockPaymentOrdersColumns[8], LockPaymentOrdersColumns[10], LockPaymentOrdersColumns[11], LockPaymentOrdersColumns[12], LockPaymentOrdersColumns[13], LockPaymentOrdersColumns[14], LockPaymentOrdersColumns[20]},
 			},
 		},
 	}
@@ -234,6 +235,7 @@ var (
 		{Name: "id", Type: field.TypeUUID},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
+		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "amount", Type: field.TypeFloat64},
 		{Name: "amount_paid", Type: field.TypeFloat64},
 		{Name: "amount_returned", Type: field.TypeFloat64},
@@ -265,25 +267,25 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "payment_orders_api_keys_payment_orders",
-				Columns:    []*schema.Column{PaymentOrdersColumns[21]},
+				Columns:    []*schema.Column{PaymentOrdersColumns[22]},
 				RefColumns: []*schema.Column{APIKeysColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "payment_orders_linked_addresses_payment_orders",
-				Columns:    []*schema.Column{PaymentOrdersColumns[22]},
+				Columns:    []*schema.Column{PaymentOrdersColumns[23]},
 				RefColumns: []*schema.Column{LinkedAddressesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "payment_orders_sender_profiles_payment_orders",
-				Columns:    []*schema.Column{PaymentOrdersColumns[23]},
+				Columns:    []*schema.Column{PaymentOrdersColumns[24]},
 				RefColumns: []*schema.Column{SenderProfilesColumns[0]},
-				OnDelete:   schema.SetNull,
+				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "payment_orders_tokens_payment_orders",
-				Columns:    []*schema.Column{PaymentOrdersColumns[24]},
+				Columns:    []*schema.Column{PaymentOrdersColumns[25]},
 				RefColumns: []*schema.Column{TokensColumns[0]},
 				OnDelete:   schema.Cascade,
 			},

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -4955,6 +4955,7 @@ type LockPaymentOrderMutation struct {
 	id                         *uuid.UUID
 	created_at                 *time.Time
 	updated_at                 *time.Time
+	deleted_at                 *time.Time
 	gateway_id                 *string
 	amount                     *decimal.Decimal
 	addamount                  *decimal.Decimal
@@ -5167,6 +5168,55 @@ func (m *LockPaymentOrderMutation) OldUpdatedAt(ctx context.Context) (v time.Tim
 // ResetUpdatedAt resets all changes to the "updated_at" field.
 func (m *LockPaymentOrderMutation) ResetUpdatedAt() {
 	m.updated_at = nil
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (m *LockPaymentOrderMutation) SetDeletedAt(t time.Time) {
+	m.deleted_at = &t
+}
+
+// DeletedAt returns the value of the "deleted_at" field in the mutation.
+func (m *LockPaymentOrderMutation) DeletedAt() (r time.Time, exists bool) {
+	v := m.deleted_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedAt returns the old "deleted_at" field's value of the LockPaymentOrder entity.
+// If the LockPaymentOrder object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *LockPaymentOrderMutation) OldDeletedAt(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedAt: %w", err)
+	}
+	return oldValue.DeletedAt, nil
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (m *LockPaymentOrderMutation) ClearDeletedAt() {
+	m.deleted_at = nil
+	m.clearedFields[lockpaymentorder.FieldDeletedAt] = struct{}{}
+}
+
+// DeletedAtCleared returns if the "deleted_at" field was cleared in this mutation.
+func (m *LockPaymentOrderMutation) DeletedAtCleared() bool {
+	_, ok := m.clearedFields[lockpaymentorder.FieldDeletedAt]
+	return ok
+}
+
+// ResetDeletedAt resets all changes to the "deleted_at" field.
+func (m *LockPaymentOrderMutation) ResetDeletedAt() {
+	m.deleted_at = nil
+	delete(m.clearedFields, lockpaymentorder.FieldDeletedAt)
 }
 
 // SetGatewayID sets the "gateway_id" field.
@@ -6086,12 +6136,15 @@ func (m *LockPaymentOrderMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *LockPaymentOrderMutation) Fields() []string {
-	fields := make([]string, 0, 16)
+	fields := make([]string, 0, 17)
 	if m.created_at != nil {
 		fields = append(fields, lockpaymentorder.FieldCreatedAt)
 	}
 	if m.updated_at != nil {
 		fields = append(fields, lockpaymentorder.FieldUpdatedAt)
+	}
+	if m.deleted_at != nil {
+		fields = append(fields, lockpaymentorder.FieldDeletedAt)
 	}
 	if m.gateway_id != nil {
 		fields = append(fields, lockpaymentorder.FieldGatewayID)
@@ -6147,6 +6200,8 @@ func (m *LockPaymentOrderMutation) Field(name string) (ent.Value, bool) {
 		return m.CreatedAt()
 	case lockpaymentorder.FieldUpdatedAt:
 		return m.UpdatedAt()
+	case lockpaymentorder.FieldDeletedAt:
+		return m.DeletedAt()
 	case lockpaymentorder.FieldGatewayID:
 		return m.GatewayID()
 	case lockpaymentorder.FieldAmount:
@@ -6188,6 +6243,8 @@ func (m *LockPaymentOrderMutation) OldField(ctx context.Context, name string) (e
 		return m.OldCreatedAt(ctx)
 	case lockpaymentorder.FieldUpdatedAt:
 		return m.OldUpdatedAt(ctx)
+	case lockpaymentorder.FieldDeletedAt:
+		return m.OldDeletedAt(ctx)
 	case lockpaymentorder.FieldGatewayID:
 		return m.OldGatewayID(ctx)
 	case lockpaymentorder.FieldAmount:
@@ -6238,6 +6295,13 @@ func (m *LockPaymentOrderMutation) SetField(name string, value ent.Value) error 
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUpdatedAt(v)
+		return nil
+	case lockpaymentorder.FieldDeletedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedAt(v)
 		return nil
 	case lockpaymentorder.FieldGatewayID:
 		v, ok := value.(string)
@@ -6430,6 +6494,9 @@ func (m *LockPaymentOrderMutation) AddField(name string, value ent.Value) error 
 // mutation.
 func (m *LockPaymentOrderMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(lockpaymentorder.FieldDeletedAt) {
+		fields = append(fields, lockpaymentorder.FieldDeletedAt)
+	}
 	if m.FieldCleared(lockpaymentorder.FieldTxHash) {
 		fields = append(fields, lockpaymentorder.FieldTxHash)
 	}
@@ -6453,6 +6520,9 @@ func (m *LockPaymentOrderMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *LockPaymentOrderMutation) ClearField(name string) error {
 	switch name {
+	case lockpaymentorder.FieldDeletedAt:
+		m.ClearDeletedAt()
+		return nil
 	case lockpaymentorder.FieldTxHash:
 		m.ClearTxHash()
 		return nil
@@ -6475,6 +6545,9 @@ func (m *LockPaymentOrderMutation) ResetField(name string) error {
 		return nil
 	case lockpaymentorder.FieldUpdatedAt:
 		m.ResetUpdatedAt()
+		return nil
+	case lockpaymentorder.FieldDeletedAt:
+		m.ResetDeletedAt()
 		return nil
 	case lockpaymentorder.FieldGatewayID:
 		m.ResetGatewayID()
@@ -7782,6 +7855,7 @@ type PaymentOrderMutation struct {
 	id                     *uuid.UUID
 	created_at             *time.Time
 	updated_at             *time.Time
+	deleted_at             *time.Time
 	amount                 *decimal.Decimal
 	addamount              *decimal.Decimal
 	amount_paid            *decimal.Decimal
@@ -8003,6 +8077,55 @@ func (m *PaymentOrderMutation) OldUpdatedAt(ctx context.Context) (v time.Time, e
 // ResetUpdatedAt resets all changes to the "updated_at" field.
 func (m *PaymentOrderMutation) ResetUpdatedAt() {
 	m.updated_at = nil
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (m *PaymentOrderMutation) SetDeletedAt(t time.Time) {
+	m.deleted_at = &t
+}
+
+// DeletedAt returns the value of the "deleted_at" field in the mutation.
+func (m *PaymentOrderMutation) DeletedAt() (r time.Time, exists bool) {
+	v := m.deleted_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedAt returns the old "deleted_at" field's value of the PaymentOrder entity.
+// If the PaymentOrder object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PaymentOrderMutation) OldDeletedAt(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedAt: %w", err)
+	}
+	return oldValue.DeletedAt, nil
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (m *PaymentOrderMutation) ClearDeletedAt() {
+	m.deleted_at = nil
+	m.clearedFields[paymentorder.FieldDeletedAt] = struct{}{}
+}
+
+// DeletedAtCleared returns if the "deleted_at" field was cleared in this mutation.
+func (m *PaymentOrderMutation) DeletedAtCleared() bool {
+	_, ok := m.clearedFields[paymentorder.FieldDeletedAt]
+	return ok
+}
+
+// ResetDeletedAt resets all changes to the "deleted_at" field.
+func (m *PaymentOrderMutation) ResetDeletedAt() {
+	m.deleted_at = nil
+	delete(m.clearedFields, paymentorder.FieldDeletedAt)
 }
 
 // SetAmount sets the "amount" field.
@@ -9214,12 +9337,15 @@ func (m *PaymentOrderMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PaymentOrderMutation) Fields() []string {
-	fields := make([]string, 0, 20)
+	fields := make([]string, 0, 21)
 	if m.created_at != nil {
 		fields = append(fields, paymentorder.FieldCreatedAt)
 	}
 	if m.updated_at != nil {
 		fields = append(fields, paymentorder.FieldUpdatedAt)
+	}
+	if m.deleted_at != nil {
+		fields = append(fields, paymentorder.FieldDeletedAt)
 	}
 	if m.amount != nil {
 		fields = append(fields, paymentorder.FieldAmount)
@@ -9287,6 +9413,8 @@ func (m *PaymentOrderMutation) Field(name string) (ent.Value, bool) {
 		return m.CreatedAt()
 	case paymentorder.FieldUpdatedAt:
 		return m.UpdatedAt()
+	case paymentorder.FieldDeletedAt:
+		return m.DeletedAt()
 	case paymentorder.FieldAmount:
 		return m.Amount()
 	case paymentorder.FieldAmountPaid:
@@ -9336,6 +9464,8 @@ func (m *PaymentOrderMutation) OldField(ctx context.Context, name string) (ent.V
 		return m.OldCreatedAt(ctx)
 	case paymentorder.FieldUpdatedAt:
 		return m.OldUpdatedAt(ctx)
+	case paymentorder.FieldDeletedAt:
+		return m.OldDeletedAt(ctx)
 	case paymentorder.FieldAmount:
 		return m.OldAmount(ctx)
 	case paymentorder.FieldAmountPaid:
@@ -9394,6 +9524,13 @@ func (m *PaymentOrderMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUpdatedAt(v)
+		return nil
+	case paymentorder.FieldDeletedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedAt(v)
 		return nil
 	case paymentorder.FieldAmount:
 		v, ok := value.(decimal.Decimal)
@@ -9674,6 +9811,9 @@ func (m *PaymentOrderMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *PaymentOrderMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(paymentorder.FieldDeletedAt) {
+		fields = append(fields, paymentorder.FieldDeletedAt)
+	}
 	if m.FieldCleared(paymentorder.FieldTxHash) {
 		fields = append(fields, paymentorder.FieldTxHash)
 	}
@@ -9706,6 +9846,9 @@ func (m *PaymentOrderMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *PaymentOrderMutation) ClearField(name string) error {
 	switch name {
+	case paymentorder.FieldDeletedAt:
+		m.ClearDeletedAt()
+		return nil
 	case paymentorder.FieldTxHash:
 		m.ClearTxHash()
 		return nil
@@ -9737,6 +9880,9 @@ func (m *PaymentOrderMutation) ResetField(name string) error {
 		return nil
 	case paymentorder.FieldUpdatedAt:
 		m.ResetUpdatedAt()
+		return nil
+	case paymentorder.FieldDeletedAt:
+		m.ResetDeletedAt()
 		return nil
 	case paymentorder.FieldAmount:
 		m.ResetAmount()

--- a/ent/paymentorder.go
+++ b/ent/paymentorder.go
@@ -28,6 +28,8 @@ type PaymentOrder struct {
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	// DeletedAt holds the value of the "deleted_at" field.
+	DeletedAt time.Time `json:"deleted_at,omitempty"`
 	// Amount holds the value of the "amount" field.
 	Amount decimal.Decimal `json:"amount,omitempty"`
 	// AmountPaid holds the value of the "amount_paid" field.
@@ -168,7 +170,7 @@ func (*PaymentOrder) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullInt64)
 		case paymentorder.FieldTxHash, paymentorder.FieldFromAddress, paymentorder.FieldReturnAddress, paymentorder.FieldReceiveAddressText, paymentorder.FieldFeeAddress, paymentorder.FieldGatewayID, paymentorder.FieldReference, paymentorder.FieldStatus:
 			values[i] = new(sql.NullString)
-		case paymentorder.FieldCreatedAt, paymentorder.FieldUpdatedAt:
+		case paymentorder.FieldCreatedAt, paymentorder.FieldUpdatedAt, paymentorder.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
 		case paymentorder.FieldID:
 			values[i] = new(uuid.UUID)
@@ -212,6 +214,12 @@ func (po *PaymentOrder) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field updated_at", values[i])
 			} else if value.Valid {
 				po.UpdatedAt = value.Time
+			}
+		case paymentorder.FieldDeletedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_at", values[i])
+			} else if value.Valid {
+				po.DeletedAt = value.Time
 			}
 		case paymentorder.FieldAmount:
 			if value, ok := values[i].(*decimal.Decimal); !ok {
@@ -420,6 +428,9 @@ func (po *PaymentOrder) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("updated_at=")
 	builder.WriteString(po.UpdatedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("deleted_at=")
+	builder.WriteString(po.DeletedAt.Format(time.ANSIC))
 	builder.WriteString(", ")
 	builder.WriteString("amount=")
 	builder.WriteString(fmt.Sprintf("%v", po.Amount))

--- a/ent/paymentorder/paymentorder.go
+++ b/ent/paymentorder/paymentorder.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"github.com/google/uuid"
@@ -20,6 +21,8 @@ const (
 	FieldCreatedAt = "created_at"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
 	FieldUpdatedAt = "updated_at"
+	// FieldDeletedAt holds the string denoting the deleted_at field in the database.
+	FieldDeletedAt = "deleted_at"
 	// FieldAmount holds the string denoting the amount field in the database.
 	FieldAmount = "amount"
 	// FieldAmountPaid holds the string denoting the amount_paid field in the database.
@@ -119,6 +122,7 @@ var Columns = []string{
 	FieldID,
 	FieldCreatedAt,
 	FieldUpdatedAt,
+	FieldDeletedAt,
 	FieldAmount,
 	FieldAmountPaid,
 	FieldAmountReturned,
@@ -163,7 +167,14 @@ func ValidColumn(column string) bool {
 	return false
 }
 
+// Note that the variables below are initialized by the runtime
+// package on the initialization of the application. Therefore,
+// it should be imported in the main as follows:
+//
+//	import _ "github.com/paycrest/aggregator/ent/runtime"
 var (
+	Hooks        [1]ent.Hook
+	Interceptors [1]ent.Interceptor
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -235,6 +246,11 @@ func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByUpdatedAt orders the results by the updated_at field.
 func ByUpdatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUpdatedAt, opts...).ToFunc()
+}
+
+// ByDeletedAt orders the results by the deleted_at field.
+func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
 }
 
 // ByAmount orders the results by the amount field.

--- a/ent/paymentorder/where.go
+++ b/ent/paymentorder/where.go
@@ -67,6 +67,11 @@ func UpdatedAt(v time.Time) predicate.PaymentOrder {
 	return predicate.PaymentOrder(sql.FieldEQ(FieldUpdatedAt, v))
 }
 
+// DeletedAt applies equality check predicate on the "deleted_at" field. It's identical to DeletedAtEQ.
+func DeletedAt(v time.Time) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldEQ(FieldDeletedAt, v))
+}
+
 // Amount applies equality check predicate on the "amount" field. It's identical to AmountEQ.
 func Amount(v decimal.Decimal) predicate.PaymentOrder {
 	return predicate.PaymentOrder(sql.FieldEQ(FieldAmount, v))
@@ -230,6 +235,56 @@ func UpdatedAtLT(v time.Time) predicate.PaymentOrder {
 // UpdatedAtLTE applies the LTE predicate on the "updated_at" field.
 func UpdatedAtLTE(v time.Time) predicate.PaymentOrder {
 	return predicate.PaymentOrder(sql.FieldLTE(FieldUpdatedAt, v))
+}
+
+// DeletedAtEQ applies the EQ predicate on the "deleted_at" field.
+func DeletedAtEQ(v time.Time) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtNEQ applies the NEQ predicate on the "deleted_at" field.
+func DeletedAtNEQ(v time.Time) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtIn applies the In predicate on the "deleted_at" field.
+func DeletedAtIn(vs ...time.Time) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtNotIn applies the NotIn predicate on the "deleted_at" field.
+func DeletedAtNotIn(vs ...time.Time) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNotIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtGT applies the GT predicate on the "deleted_at" field.
+func DeletedAtGT(v time.Time) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldGT(FieldDeletedAt, v))
+}
+
+// DeletedAtGTE applies the GTE predicate on the "deleted_at" field.
+func DeletedAtGTE(v time.Time) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldGTE(FieldDeletedAt, v))
+}
+
+// DeletedAtLT applies the LT predicate on the "deleted_at" field.
+func DeletedAtLT(v time.Time) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldLT(FieldDeletedAt, v))
+}
+
+// DeletedAtLTE applies the LTE predicate on the "deleted_at" field.
+func DeletedAtLTE(v time.Time) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldLTE(FieldDeletedAt, v))
+}
+
+// DeletedAtIsNil applies the IsNil predicate on the "deleted_at" field.
+func DeletedAtIsNil() predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldIsNull(FieldDeletedAt))
+}
+
+// DeletedAtNotNil applies the NotNil predicate on the "deleted_at" field.
+func DeletedAtNotNil() predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNotNull(FieldDeletedAt))
 }
 
 // AmountEQ applies the EQ predicate on the "amount" field.

--- a/ent/paymentorder_create.go
+++ b/ent/paymentorder_create.go
@@ -59,6 +59,20 @@ func (poc *PaymentOrderCreate) SetNillableUpdatedAt(t *time.Time) *PaymentOrderC
 	return poc
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (poc *PaymentOrderCreate) SetDeletedAt(t time.Time) *PaymentOrderCreate {
+	poc.mutation.SetDeletedAt(t)
+	return poc
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (poc *PaymentOrderCreate) SetNillableDeletedAt(t *time.Time) *PaymentOrderCreate {
+	if t != nil {
+		poc.SetDeletedAt(*t)
+	}
+	return poc
+}
+
 // SetAmount sets the "amount" field.
 func (poc *PaymentOrderCreate) SetAmount(d decimal.Decimal) *PaymentOrderCreate {
 	poc.mutation.SetAmount(d)
@@ -354,7 +368,9 @@ func (poc *PaymentOrderCreate) Mutation() *PaymentOrderMutation {
 
 // Save creates the PaymentOrder in the database.
 func (poc *PaymentOrderCreate) Save(ctx context.Context) (*PaymentOrder, error) {
-	poc.defaults()
+	if err := poc.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, poc.sqlSave, poc.mutation, poc.hooks)
 }
 
@@ -381,12 +397,18 @@ func (poc *PaymentOrderCreate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (poc *PaymentOrderCreate) defaults() {
+func (poc *PaymentOrderCreate) defaults() error {
 	if _, ok := poc.mutation.CreatedAt(); !ok {
+		if paymentorder.DefaultCreatedAt == nil {
+			return fmt.Errorf("ent: uninitialized paymentorder.DefaultCreatedAt (forgotten import ent/runtime?)")
+		}
 		v := paymentorder.DefaultCreatedAt()
 		poc.mutation.SetCreatedAt(v)
 	}
 	if _, ok := poc.mutation.UpdatedAt(); !ok {
+		if paymentorder.DefaultUpdatedAt == nil {
+			return fmt.Errorf("ent: uninitialized paymentorder.DefaultUpdatedAt (forgotten import ent/runtime?)")
+		}
 		v := paymentorder.DefaultUpdatedAt()
 		poc.mutation.SetUpdatedAt(v)
 	}
@@ -399,9 +421,13 @@ func (poc *PaymentOrderCreate) defaults() {
 		poc.mutation.SetStatus(v)
 	}
 	if _, ok := poc.mutation.ID(); !ok {
+		if paymentorder.DefaultID == nil {
+			return fmt.Errorf("ent: uninitialized paymentorder.DefaultID (forgotten import ent/runtime?)")
+		}
 		v := paymentorder.DefaultID()
 		poc.mutation.SetID(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -534,6 +560,10 @@ func (poc *PaymentOrderCreate) createSpec() (*PaymentOrder, *sqlgraph.CreateSpec
 	if value, ok := poc.mutation.UpdatedAt(); ok {
 		_spec.SetField(paymentorder.FieldUpdatedAt, field.TypeTime, value)
 		_node.UpdatedAt = value
+	}
+	if value, ok := poc.mutation.DeletedAt(); ok {
+		_spec.SetField(paymentorder.FieldDeletedAt, field.TypeTime, value)
+		_node.DeletedAt = value
 	}
 	if value, ok := poc.mutation.Amount(); ok {
 		_spec.SetField(paymentorder.FieldAmount, field.TypeFloat64, value)
@@ -767,6 +797,24 @@ func (u *PaymentOrderUpsert) SetUpdatedAt(v time.Time) *PaymentOrderUpsert {
 // UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
 func (u *PaymentOrderUpsert) UpdateUpdatedAt() *PaymentOrderUpsert {
 	u.SetExcluded(paymentorder.FieldUpdatedAt)
+	return u
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (u *PaymentOrderUpsert) SetDeletedAt(v time.Time) *PaymentOrderUpsert {
+	u.Set(paymentorder.FieldDeletedAt, v)
+	return u
+}
+
+// UpdateDeletedAt sets the "deleted_at" field to the value that was provided on create.
+func (u *PaymentOrderUpsert) UpdateDeletedAt() *PaymentOrderUpsert {
+	u.SetExcluded(paymentorder.FieldDeletedAt)
+	return u
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (u *PaymentOrderUpsert) ClearDeletedAt() *PaymentOrderUpsert {
+	u.SetNull(paymentorder.FieldDeletedAt)
 	return u
 }
 
@@ -1144,6 +1192,27 @@ func (u *PaymentOrderUpsertOne) SetUpdatedAt(v time.Time) *PaymentOrderUpsertOne
 func (u *PaymentOrderUpsertOne) UpdateUpdatedAt() *PaymentOrderUpsertOne {
 	return u.Update(func(s *PaymentOrderUpsert) {
 		s.UpdateUpdatedAt()
+	})
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (u *PaymentOrderUpsertOne) SetDeletedAt(v time.Time) *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.SetDeletedAt(v)
+	})
+}
+
+// UpdateDeletedAt sets the "deleted_at" field to the value that was provided on create.
+func (u *PaymentOrderUpsertOne) UpdateDeletedAt() *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.UpdateDeletedAt()
+	})
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (u *PaymentOrderUpsertOne) ClearDeletedAt() *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.ClearDeletedAt()
 	})
 }
 
@@ -1740,6 +1809,27 @@ func (u *PaymentOrderUpsertBulk) SetUpdatedAt(v time.Time) *PaymentOrderUpsertBu
 func (u *PaymentOrderUpsertBulk) UpdateUpdatedAt() *PaymentOrderUpsertBulk {
 	return u.Update(func(s *PaymentOrderUpsert) {
 		s.UpdateUpdatedAt()
+	})
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (u *PaymentOrderUpsertBulk) SetDeletedAt(v time.Time) *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.SetDeletedAt(v)
+	})
+}
+
+// UpdateDeletedAt sets the "deleted_at" field to the value that was provided on create.
+func (u *PaymentOrderUpsertBulk) UpdateDeletedAt() *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.UpdateDeletedAt()
+	})
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (u *PaymentOrderUpsertBulk) ClearDeletedAt() *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.ClearDeletedAt()
 	})
 }
 

--- a/ent/paymentorder_update.go
+++ b/ent/paymentorder_update.go
@@ -42,6 +42,26 @@ func (pou *PaymentOrderUpdate) SetUpdatedAt(t time.Time) *PaymentOrderUpdate {
 	return pou
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (pou *PaymentOrderUpdate) SetDeletedAt(t time.Time) *PaymentOrderUpdate {
+	pou.mutation.SetDeletedAt(t)
+	return pou
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (pou *PaymentOrderUpdate) SetNillableDeletedAt(t *time.Time) *PaymentOrderUpdate {
+	if t != nil {
+		pou.SetDeletedAt(*t)
+	}
+	return pou
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (pou *PaymentOrderUpdate) ClearDeletedAt() *PaymentOrderUpdate {
+	pou.mutation.ClearDeletedAt()
+	return pou
+}
+
 // SetAmount sets the "amount" field.
 func (pou *PaymentOrderUpdate) SetAmount(d decimal.Decimal) *PaymentOrderUpdate {
 	pou.mutation.ResetAmount()
@@ -560,7 +580,9 @@ func (pou *PaymentOrderUpdate) RemoveTransactions(t ...*TransactionLog) *Payment
 
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (pou *PaymentOrderUpdate) Save(ctx context.Context) (int, error) {
-	pou.defaults()
+	if err := pou.defaults(); err != nil {
+		return 0, err
+	}
 	return withHooks(ctx, pou.sqlSave, pou.mutation, pou.hooks)
 }
 
@@ -587,11 +609,15 @@ func (pou *PaymentOrderUpdate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (pou *PaymentOrderUpdate) defaults() {
+func (pou *PaymentOrderUpdate) defaults() error {
 	if _, ok := pou.mutation.UpdatedAt(); !ok {
+		if paymentorder.UpdateDefaultUpdatedAt == nil {
+			return fmt.Errorf("ent: uninitialized paymentorder.UpdateDefaultUpdatedAt (forgotten import ent/runtime?)")
+		}
 		v := paymentorder.UpdateDefaultUpdatedAt()
 		pou.mutation.SetUpdatedAt(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -656,6 +682,12 @@ func (pou *PaymentOrderUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := pou.mutation.UpdatedAt(); ok {
 		_spec.SetField(paymentorder.FieldUpdatedAt, field.TypeTime, value)
+	}
+	if value, ok := pou.mutation.DeletedAt(); ok {
+		_spec.SetField(paymentorder.FieldDeletedAt, field.TypeTime, value)
+	}
+	if pou.mutation.DeletedAtCleared() {
+		_spec.ClearField(paymentorder.FieldDeletedAt, field.TypeTime)
 	}
 	if value, ok := pou.mutation.Amount(); ok {
 		_spec.SetField(paymentorder.FieldAmount, field.TypeFloat64, value)
@@ -972,6 +1004,26 @@ type PaymentOrderUpdateOne struct {
 // SetUpdatedAt sets the "updated_at" field.
 func (pouo *PaymentOrderUpdateOne) SetUpdatedAt(t time.Time) *PaymentOrderUpdateOne {
 	pouo.mutation.SetUpdatedAt(t)
+	return pouo
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (pouo *PaymentOrderUpdateOne) SetDeletedAt(t time.Time) *PaymentOrderUpdateOne {
+	pouo.mutation.SetDeletedAt(t)
+	return pouo
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (pouo *PaymentOrderUpdateOne) SetNillableDeletedAt(t *time.Time) *PaymentOrderUpdateOne {
+	if t != nil {
+		pouo.SetDeletedAt(*t)
+	}
+	return pouo
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (pouo *PaymentOrderUpdateOne) ClearDeletedAt() *PaymentOrderUpdateOne {
+	pouo.mutation.ClearDeletedAt()
 	return pouo
 }
 
@@ -1506,7 +1558,9 @@ func (pouo *PaymentOrderUpdateOne) Select(field string, fields ...string) *Payme
 
 // Save executes the query and returns the updated PaymentOrder entity.
 func (pouo *PaymentOrderUpdateOne) Save(ctx context.Context) (*PaymentOrder, error) {
-	pouo.defaults()
+	if err := pouo.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, pouo.sqlSave, pouo.mutation, pouo.hooks)
 }
 
@@ -1533,11 +1587,15 @@ func (pouo *PaymentOrderUpdateOne) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (pouo *PaymentOrderUpdateOne) defaults() {
+func (pouo *PaymentOrderUpdateOne) defaults() error {
 	if _, ok := pouo.mutation.UpdatedAt(); !ok {
+		if paymentorder.UpdateDefaultUpdatedAt == nil {
+			return fmt.Errorf("ent: uninitialized paymentorder.UpdateDefaultUpdatedAt (forgotten import ent/runtime?)")
+		}
 		v := paymentorder.UpdateDefaultUpdatedAt()
 		pouo.mutation.SetUpdatedAt(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -1619,6 +1677,12 @@ func (pouo *PaymentOrderUpdateOne) sqlSave(ctx context.Context) (_node *PaymentO
 	}
 	if value, ok := pouo.mutation.UpdatedAt(); ok {
 		_spec.SetField(paymentorder.FieldUpdatedAt, field.TypeTime, value)
+	}
+	if value, ok := pouo.mutation.DeletedAt(); ok {
+		_spec.SetField(paymentorder.FieldDeletedAt, field.TypeTime, value)
+	}
+	if pouo.mutation.DeletedAtCleared() {
+		_spec.ClearField(paymentorder.FieldDeletedAt, field.TypeTime)
 	}
 	if value, ok := pouo.mutation.Amount(); ok {
 		_spec.SetField(paymentorder.FieldAmount, field.TypeFloat64, value)

--- a/ent/runtime/runtime.go
+++ b/ent/runtime/runtime.go
@@ -145,6 +145,10 @@ func init() {
 	// lockorderfulfillment.DefaultID holds the default value on creation for the id field.
 	lockorderfulfillment.DefaultID = lockorderfulfillmentDescID.Default.(func() uuid.UUID)
 	lockpaymentorderMixin := schema.LockPaymentOrder{}.Mixin()
+	lockpaymentorderMixinHooks1 := lockpaymentorderMixin[1].Hooks()
+	lockpaymentorder.Hooks[0] = lockpaymentorderMixinHooks1[0]
+	lockpaymentorderMixinInters1 := lockpaymentorderMixin[1].Interceptors()
+	lockpaymentorder.Interceptors[0] = lockpaymentorderMixinInters1[0]
 	lockpaymentorderMixinFields0 := lockpaymentorderMixin[0].Fields()
 	_ = lockpaymentorderMixinFields0
 	lockpaymentorderFields := schema.LockPaymentOrder{}.Fields()
@@ -195,6 +199,10 @@ func init() {
 	// network.DefaultGatewayContractAddress holds the default value on creation for the gateway_contract_address field.
 	network.DefaultGatewayContractAddress = networkDescGatewayContractAddress.Default.(string)
 	paymentorderMixin := schema.PaymentOrder{}.Mixin()
+	paymentorderMixinHooks1 := paymentorderMixin[1].Hooks()
+	paymentorder.Hooks[0] = paymentorderMixinHooks1[0]
+	paymentorderMixinInters1 := paymentorderMixin[1].Interceptors()
+	paymentorder.Interceptors[0] = paymentorderMixinInters1[0]
 	paymentorderMixinFields0 := paymentorderMixin[0].Fields()
 	_ = paymentorderMixinFields0
 	paymentorderFields := schema.PaymentOrder{}.Fields()

--- a/ent/schema/lockpaymentorder.go
+++ b/ent/schema/lockpaymentorder.go
@@ -19,6 +19,7 @@ type LockPaymentOrder struct {
 func (LockPaymentOrder) Mixin() []ent.Mixin {
 	return []ent.Mixin{
 		TimeMixin{},
+		SoftDeleteMixin{},
 	}
 }
 

--- a/ent/schema/mixins.go
+++ b/ent/schema/mixins.go
@@ -1,11 +1,16 @@
 package schema
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/mixin"
+	entclient "github.com/paycrest/aggregator/ent"
+	"github.com/paycrest/aggregator/ent/hook"
 )
 
 // -------------------------------------------------
@@ -28,5 +33,84 @@ func (TimeMixin) Fields() []ent.Field {
 		field.Time("updated_at").
 			Default(time.Now).
 			UpdateDefault(time.Now),
+	}
+}
+
+// SoftDeleteMixin provides soft delete functionality.
+type SoftDeleteMixin struct {
+	mixin.Schema
+}
+
+// Fields of the SoftDeleteMixin.
+func (SoftDeleteMixin) Fields() []ent.Field {
+	return []ent.Field{
+		field.Time("deleted_at").
+			Optional().
+			Nillable(),
+	}
+}
+
+// softDeleteKey is the context key for skipping soft delete.
+type softDeleteKey struct{}
+
+func (SoftDeleteMixin) P(q interface {
+	WhereP(...func(*sql.Selector))
+}) {
+	q.WhereP(func(s *sql.Selector) {
+		s.Where(sql.IsNull("deleted_at"))
+	})
+}
+
+// SkipSoftDelete returns a new context that skips the soft-delete interceptor/mutators.
+func SkipSoftDelete(parent context.Context) context.Context {
+	return context.WithValue(parent, softDeleteKey{}, true)
+}
+
+func (d SoftDeleteMixin) Interceptors() []ent.Interceptor {
+	return []ent.Interceptor{
+		ent.TraverseFunc(func(ctx context.Context, q ent.Query) error {
+			// Skip soft-delete, means include soft-deleted entities.
+			if skip, _ := ctx.Value(softDeleteKey{}).(bool); skip {
+				return nil
+			}
+
+			if wp, ok := q.(interface {
+				WhereP(...func(*sql.Selector))
+			}); ok {
+				wp.WhereP(sql.FieldIsNull("deleted_at"))
+			}
+
+			return nil
+		}),
+	}
+}
+
+// Hooks of the SoftDeleteMixin.
+func (d SoftDeleteMixin) Hooks() []ent.Hook {
+	return []ent.Hook{
+		hook.On(
+			func(next ent.Mutator) ent.Mutator {
+				return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
+					// Skip soft-delete, means delete the entity permanently.
+					if skip, _ := ctx.Value(softDeleteKey{}).(bool); skip {
+						return next.Mutate(ctx, m)
+					}
+					mx, ok := m.(interface {
+						SetOp(ent.Op)
+						Client() *entclient.Client
+						SetDeleteTime(time.Time)
+						WhereP(...func(*sql.Selector))
+					})
+					if !ok {
+						return nil, fmt.Errorf("unexpected mutation type %T", m)
+					}
+					d.P(mx)
+					mx.SetOp(ent.OpUpdate)
+					mx.SetDeleteTime(time.Now())
+					return mx.Client().Mutate(ctx, m)
+				})
+			},
+			ent.OpDeleteOne|ent.OpDelete,
+		),
 	}
 }

--- a/ent/schema/paymentorder.go
+++ b/ent/schema/paymentorder.go
@@ -18,6 +18,7 @@ type PaymentOrder struct {
 func (PaymentOrder) Mixin() []ent.Mixin {
 	return []ent.Mixin{
 		TimeMixin{},
+		SoftDeleteMixin{},
 	}
 }
 

--- a/ent/schema/senderprofile.go
+++ b/ent/schema/senderprofile.go
@@ -45,7 +45,7 @@ func (SenderProfile) Edges() []ent.Edge {
 			Unique().
 			Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.To("payment_orders", PaymentOrder.Type).
-			Annotations(entsql.OnDelete(entsql.SetNull)),
+			Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.To("order_tokens", SenderOrderToken.Type).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.To("linked_address", LinkedAddress.Type).


### PR DESCRIPTION
### Description

This PR implements soft delete functionality for `PaymentOrder` and `LockPaymentOrder` entities in the `paycrest/aggregator` repository. The purpose is to maintain data integrity and audit history by soft deleting payment orders instead of permanently removing them, while allowing cleanup of old records. The changes ensure that normal deletions set the `deleted_at` timestamp, queries exclude soft-deleted records by default, and the `SkipSoftDelete` context retrieves all records. Cascading deletes from `SenderProfile` soft delete associated payment orders.

### The Implementation includes

- Created a `SoftDeleteMixin` in `schema/mixins.go` following Ent's soft delete pattern.
- Added SoftDeleteMixin to both `PaymentOrder` and `LockPaymentOrder` schemas.
- Update [PaymentOrder edge](https://github.com/paycrest/aggregator/blob/d91fd66610ec6085a34ecf2f2dfd945be225aba1/ent/schema/senderprofile.go#L47) in SenderProfile to use entsql.Cascade
- Added `SkipSoftDelete` context utility function
- Created database migration for new `deleted_at` field
- Added soft delete functionality to `LockPaymentOrder` and `PaymentOrder` schemas

# References
closes #401 

### Testing
Tests were not included per ticket instruction.

### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
