### PR TITLE
feat: implement provide profile availability

### DIFF
--- a/controllers/accounts/profile.go
+++ b/controllers/accounts/profile.go
@@ -250,10 +250,9 @@ func (ctrl *ProfileController) UpdateProviderProfile(ctx *gin.Context) {
 		update.SetHostIdentifier(payload.HostIdentifier)
 	}
 
-	if payload.IsAvailable {
-		update.SetIsAvailable(true)
-	} else {
-		update.SetIsAvailable(false)
+	// --- Replace is_available with available_for ---
+	if len(payload.AvailableFor) > 0 {
+		update.SetAvailableFor(payload.AvailableFor)
 	}
 
 	if len(payload.Currencies) > 0 {
@@ -748,7 +747,7 @@ func (ctrl *ProfileController) GetProviderProfile(ctx *gin.Context) {
 		TradingName:          provider.TradingName,
 		Currencies:           currencyCodes,
 		HostIdentifier:       provider.HostIdentifier,
-		IsAvailable:          provider.IsAvailable,
+		AvailableFor:         provider.AvailableFor,
 		Tokens:               tokensPayload,
 		APIKey:               *apiKey,
 		IsActive:             provider.IsActive,

--- a/controllers/accounts/profile_test.go
+++ b/controllers/accounts/profile_test.go
@@ -369,7 +369,7 @@ func TestProfile(t *testing.T) {
 				HostIdentifier:   "https://example.com",
 				BusinessDocument: "https://example.com/business_doc.png",
 				IdentityDocument: "https://example.com/national_id.png",
-				IsAvailable:      true,
+				AvailableFor:     []string{"KES", "USD"},
 			}
 
 			res := profileUpdateRequest(payload)
@@ -398,6 +398,7 @@ func TestProfile(t *testing.T) {
 			// assert for currencies
 			assert.Equal(t, len(providerProfile.Edges.Currencies), 1)
 			assert.Equal(t, providerProfile.Edges.Currencies[0].Code, payload.Currencies[0])
+			assert.ElementsMatch(t, payload.AvailableFor, providerProfile.AvailableFor) // <-- Assert AvailableFor
 		})
 
 		t.Run("with token rate slippage", func(t *testing.T) {

--- a/controllers/index.go
+++ b/controllers/index.go
@@ -364,8 +364,10 @@ func (ctrl *Controller) VerifyAccount(ctx *gin.Context) {
 			),
 			providerprofile.HostIdentifierNotNil(),
 			providerprofile.IsActiveEQ(true),
-			providerprofile.IsAvailableEQ(true),
+			// Remove: providerprofile.IsAvailableEQ(true),
 			providerprofile.VisibilityModeEQ(providerprofile.VisibilityModePublic),
+			// Add: provider is available for the institution's currency
+			providerprofile.AvailableForContains(accountInstitution.Edges.FiatCurrency.Code),
 		).
 		All(ctx)
 	if err != nil {

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -371,7 +371,6 @@ var (
 		{Name: "host_identifier", Type: field.TypeString, Nullable: true},
 		{Name: "provision_mode", Type: field.TypeEnum, Enums: []string{"manual", "auto"}, Default: "auto"},
 		{Name: "is_active", Type: field.TypeBool, Default: false},
-		{Name: "is_available", Type: field.TypeBool, Default: false},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "visibility_mode", Type: field.TypeEnum, Enums: []string{"private", "public"}, Default: "public"},
 		{Name: "address", Type: field.TypeString, Nullable: true, Size: 2147483647},
@@ -382,6 +381,7 @@ var (
 		{Name: "identity_document", Type: field.TypeString, Nullable: true},
 		{Name: "business_document", Type: field.TypeString, Nullable: true},
 		{Name: "is_kyb_verified", Type: field.TypeBool, Default: false},
+		{Name: "available_for", Type: field.TypeJSON, Nullable: true},
 		{Name: "user_provider_profile", Type: field.TypeUUID, Unique: true},
 	}
 	// ProviderProfilesTable holds the schema information for the "provider_profiles" table.

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -11909,7 +11909,6 @@ type ProviderProfileMutation struct {
 	host_identifier          *string
 	provision_mode           *providerprofile.ProvisionMode
 	is_active                *bool
-	is_available             *bool
 	updated_at               *time.Time
 	visibility_mode          *providerprofile.VisibilityMode
 	address                  *string
@@ -11920,6 +11919,8 @@ type ProviderProfileMutation struct {
 	identity_document        *string
 	business_document        *string
 	is_kyb_verified          *bool
+	available_for            *[]string
+	appendavailable_for      []string
 	clearedFields            map[string]struct{}
 	user                     *uuid.UUID
 	cleareduser              bool
@@ -12216,42 +12217,6 @@ func (m *ProviderProfileMutation) OldIsActive(ctx context.Context) (v bool, err 
 // ResetIsActive resets all changes to the "is_active" field.
 func (m *ProviderProfileMutation) ResetIsActive() {
 	m.is_active = nil
-}
-
-// SetIsAvailable sets the "is_available" field.
-func (m *ProviderProfileMutation) SetIsAvailable(b bool) {
-	m.is_available = &b
-}
-
-// IsAvailable returns the value of the "is_available" field in the mutation.
-func (m *ProviderProfileMutation) IsAvailable() (r bool, exists bool) {
-	v := m.is_available
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldIsAvailable returns the old "is_available" field's value of the ProviderProfile entity.
-// If the ProviderProfile object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ProviderProfileMutation) OldIsAvailable(ctx context.Context) (v bool, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldIsAvailable is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldIsAvailable requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldIsAvailable: %w", err)
-	}
-	return oldValue.IsAvailable, nil
-}
-
-// ResetIsAvailable resets all changes to the "is_available" field.
-func (m *ProviderProfileMutation) ResetIsAvailable() {
-	m.is_available = nil
 }
 
 // SetUpdatedAt sets the "updated_at" field.
@@ -12705,6 +12670,71 @@ func (m *ProviderProfileMutation) ResetIsKybVerified() {
 	m.is_kyb_verified = nil
 }
 
+// SetAvailableFor sets the "available_for" field.
+func (m *ProviderProfileMutation) SetAvailableFor(s []string) {
+	m.available_for = &s
+	m.appendavailable_for = nil
+}
+
+// AvailableFor returns the value of the "available_for" field in the mutation.
+func (m *ProviderProfileMutation) AvailableFor() (r []string, exists bool) {
+	v := m.available_for
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAvailableFor returns the old "available_for" field's value of the ProviderProfile entity.
+// If the ProviderProfile object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ProviderProfileMutation) OldAvailableFor(ctx context.Context) (v []string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAvailableFor is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAvailableFor requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAvailableFor: %w", err)
+	}
+	return oldValue.AvailableFor, nil
+}
+
+// AppendAvailableFor adds s to the "available_for" field.
+func (m *ProviderProfileMutation) AppendAvailableFor(s []string) {
+	m.appendavailable_for = append(m.appendavailable_for, s...)
+}
+
+// AppendedAvailableFor returns the list of values that were appended to the "available_for" field in this mutation.
+func (m *ProviderProfileMutation) AppendedAvailableFor() ([]string, bool) {
+	if len(m.appendavailable_for) == 0 {
+		return nil, false
+	}
+	return m.appendavailable_for, true
+}
+
+// ClearAvailableFor clears the value of the "available_for" field.
+func (m *ProviderProfileMutation) ClearAvailableFor() {
+	m.available_for = nil
+	m.appendavailable_for = nil
+	m.clearedFields[providerprofile.FieldAvailableFor] = struct{}{}
+}
+
+// AvailableForCleared returns if the "available_for" field was cleared in this mutation.
+func (m *ProviderProfileMutation) AvailableForCleared() bool {
+	_, ok := m.clearedFields[providerprofile.FieldAvailableFor]
+	return ok
+}
+
+// ResetAvailableFor resets all changes to the "available_for" field.
+func (m *ProviderProfileMutation) ResetAvailableFor() {
+	m.available_for = nil
+	m.appendavailable_for = nil
+	delete(m.clearedFields, providerprofile.FieldAvailableFor)
+}
+
 // SetUserID sets the "user" edge to the User entity by id.
 func (m *ProviderProfileMutation) SetUserID(id uuid.UUID) {
 	m.user = &id
@@ -13085,9 +13115,6 @@ func (m *ProviderProfileMutation) Fields() []string {
 	if m.is_active != nil {
 		fields = append(fields, providerprofile.FieldIsActive)
 	}
-	if m.is_available != nil {
-		fields = append(fields, providerprofile.FieldIsAvailable)
-	}
 	if m.updated_at != nil {
 		fields = append(fields, providerprofile.FieldUpdatedAt)
 	}
@@ -13118,6 +13145,9 @@ func (m *ProviderProfileMutation) Fields() []string {
 	if m.is_kyb_verified != nil {
 		fields = append(fields, providerprofile.FieldIsKybVerified)
 	}
+	if m.available_for != nil {
+		fields = append(fields, providerprofile.FieldAvailableFor)
+	}
 	return fields
 }
 
@@ -13134,8 +13164,6 @@ func (m *ProviderProfileMutation) Field(name string) (ent.Value, bool) {
 		return m.ProvisionMode()
 	case providerprofile.FieldIsActive:
 		return m.IsActive()
-	case providerprofile.FieldIsAvailable:
-		return m.IsAvailable()
 	case providerprofile.FieldUpdatedAt:
 		return m.UpdatedAt()
 	case providerprofile.FieldVisibilityMode:
@@ -13156,6 +13184,8 @@ func (m *ProviderProfileMutation) Field(name string) (ent.Value, bool) {
 		return m.BusinessDocument()
 	case providerprofile.FieldIsKybVerified:
 		return m.IsKybVerified()
+	case providerprofile.FieldAvailableFor:
+		return m.AvailableFor()
 	}
 	return nil, false
 }
@@ -13173,8 +13203,6 @@ func (m *ProviderProfileMutation) OldField(ctx context.Context, name string) (en
 		return m.OldProvisionMode(ctx)
 	case providerprofile.FieldIsActive:
 		return m.OldIsActive(ctx)
-	case providerprofile.FieldIsAvailable:
-		return m.OldIsAvailable(ctx)
 	case providerprofile.FieldUpdatedAt:
 		return m.OldUpdatedAt(ctx)
 	case providerprofile.FieldVisibilityMode:
@@ -13195,6 +13223,8 @@ func (m *ProviderProfileMutation) OldField(ctx context.Context, name string) (en
 		return m.OldBusinessDocument(ctx)
 	case providerprofile.FieldIsKybVerified:
 		return m.OldIsKybVerified(ctx)
+	case providerprofile.FieldAvailableFor:
+		return m.OldAvailableFor(ctx)
 	}
 	return nil, fmt.Errorf("unknown ProviderProfile field %s", name)
 }
@@ -13231,13 +13261,6 @@ func (m *ProviderProfileMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetIsActive(v)
-		return nil
-	case providerprofile.FieldIsAvailable:
-		v, ok := value.(bool)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetIsAvailable(v)
 		return nil
 	case providerprofile.FieldUpdatedAt:
 		v, ok := value.(time.Time)
@@ -13309,6 +13332,13 @@ func (m *ProviderProfileMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetIsKybVerified(v)
 		return nil
+	case providerprofile.FieldAvailableFor:
+		v, ok := value.([]string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAvailableFor(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ProviderProfile field %s", name)
 }
@@ -13366,6 +13396,9 @@ func (m *ProviderProfileMutation) ClearedFields() []string {
 	if m.FieldCleared(providerprofile.FieldBusinessDocument) {
 		fields = append(fields, providerprofile.FieldBusinessDocument)
 	}
+	if m.FieldCleared(providerprofile.FieldAvailableFor) {
+		fields = append(fields, providerprofile.FieldAvailableFor)
+	}
 	return fields
 }
 
@@ -13407,6 +13440,9 @@ func (m *ProviderProfileMutation) ClearField(name string) error {
 	case providerprofile.FieldBusinessDocument:
 		m.ClearBusinessDocument()
 		return nil
+	case providerprofile.FieldAvailableFor:
+		m.ClearAvailableFor()
+		return nil
 	}
 	return fmt.Errorf("unknown ProviderProfile nullable field %s", name)
 }
@@ -13426,9 +13462,6 @@ func (m *ProviderProfileMutation) ResetField(name string) error {
 		return nil
 	case providerprofile.FieldIsActive:
 		m.ResetIsActive()
-		return nil
-	case providerprofile.FieldIsAvailable:
-		m.ResetIsAvailable()
 		return nil
 	case providerprofile.FieldUpdatedAt:
 		m.ResetUpdatedAt()
@@ -13459,6 +13492,9 @@ func (m *ProviderProfileMutation) ResetField(name string) error {
 		return nil
 	case providerprofile.FieldIsKybVerified:
 		m.ResetIsKybVerified()
+		return nil
+	case providerprofile.FieldAvailableFor:
+		m.ResetAvailableFor()
 		return nil
 	}
 	return fmt.Errorf("unknown ProviderProfile field %s", name)

--- a/ent/providerprofile/providerprofile.go
+++ b/ent/providerprofile/providerprofile.go
@@ -23,8 +23,6 @@ const (
 	FieldProvisionMode = "provision_mode"
 	// FieldIsActive holds the string denoting the is_active field in the database.
 	FieldIsActive = "is_active"
-	// FieldIsAvailable holds the string denoting the is_available field in the database.
-	FieldIsAvailable = "is_available"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
 	FieldUpdatedAt = "updated_at"
 	// FieldVisibilityMode holds the string denoting the visibility_mode field in the database.
@@ -45,6 +43,8 @@ const (
 	FieldBusinessDocument = "business_document"
 	// FieldIsKybVerified holds the string denoting the is_kyb_verified field in the database.
 	FieldIsKybVerified = "is_kyb_verified"
+	// FieldAvailableFor holds the string denoting the available_for field in the database.
+	FieldAvailableFor = "available_for"
 	// EdgeUser holds the string denoting the user edge name in mutations.
 	EdgeUser = "user"
 	// EdgeAPIKey holds the string denoting the api_key edge name in mutations.
@@ -115,7 +115,6 @@ var Columns = []string{
 	FieldHostIdentifier,
 	FieldProvisionMode,
 	FieldIsActive,
-	FieldIsAvailable,
 	FieldUpdatedAt,
 	FieldVisibilityMode,
 	FieldAddress,
@@ -126,6 +125,7 @@ var Columns = []string{
 	FieldIdentityDocument,
 	FieldBusinessDocument,
 	FieldIsKybVerified,
+	FieldAvailableFor,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the "provider_profiles"
@@ -163,8 +163,6 @@ var (
 	TradingNameValidator func(string) error
 	// DefaultIsActive holds the default value on creation for the "is_active" field.
 	DefaultIsActive bool
-	// DefaultIsAvailable holds the default value on creation for the "is_available" field.
-	DefaultIsAvailable bool
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
 	DefaultUpdatedAt func() time.Time
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.
@@ -277,11 +275,6 @@ func ByProvisionMode(opts ...sql.OrderTermOption) OrderOption {
 // ByIsActive orders the results by the is_active field.
 func ByIsActive(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldIsActive, opts...).ToFunc()
-}
-
-// ByIsAvailable orders the results by the is_available field.
-func ByIsAvailable(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldIsAvailable, opts...).ToFunc()
 }
 
 // ByUpdatedAt orders the results by the updated_at field.

--- a/ent/providerprofile/where.go
+++ b/ent/providerprofile/where.go
@@ -80,11 +80,6 @@ func IsActive(v bool) predicate.ProviderProfile {
 	return predicate.ProviderProfile(sql.FieldEQ(FieldIsActive, v))
 }
 
-// IsAvailable applies equality check predicate on the "is_available" field. It's identical to IsAvailableEQ.
-func IsAvailable(v bool) predicate.ProviderProfile {
-	return predicate.ProviderProfile(sql.FieldEQ(FieldIsAvailable, v))
-}
-
 // UpdatedAt applies equality check predicate on the "updated_at" field. It's identical to UpdatedAtEQ.
 func UpdatedAt(v time.Time) predicate.ProviderProfile {
 	return predicate.ProviderProfile(sql.FieldEQ(FieldUpdatedAt, v))
@@ -303,16 +298,6 @@ func IsActiveEQ(v bool) predicate.ProviderProfile {
 // IsActiveNEQ applies the NEQ predicate on the "is_active" field.
 func IsActiveNEQ(v bool) predicate.ProviderProfile {
 	return predicate.ProviderProfile(sql.FieldNEQ(FieldIsActive, v))
-}
-
-// IsAvailableEQ applies the EQ predicate on the "is_available" field.
-func IsAvailableEQ(v bool) predicate.ProviderProfile {
-	return predicate.ProviderProfile(sql.FieldEQ(FieldIsAvailable, v))
-}
-
-// IsAvailableNEQ applies the NEQ predicate on the "is_available" field.
-func IsAvailableNEQ(v bool) predicate.ProviderProfile {
-	return predicate.ProviderProfile(sql.FieldNEQ(FieldIsAvailable, v))
 }
 
 // UpdatedAtEQ applies the EQ predicate on the "updated_at" field.
@@ -838,6 +823,26 @@ func IsKybVerifiedEQ(v bool) predicate.ProviderProfile {
 // IsKybVerifiedNEQ applies the NEQ predicate on the "is_kyb_verified" field.
 func IsKybVerifiedNEQ(v bool) predicate.ProviderProfile {
 	return predicate.ProviderProfile(sql.FieldNEQ(FieldIsKybVerified, v))
+}
+
+// AvailableForIsNil applies the IsNil predicate on the "available_for" field.
+func AvailableForIsNil() predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldIsNull(FieldAvailableFor))
+}
+
+// AvailableForNotNil applies the NotNil predicate on the "available_for" field.
+func AvailableForNotNil() predicate.ProviderProfile {
+	return predicate.ProviderProfile(sql.FieldNotNull(FieldAvailableFor))
+}
+
+// AvailableForContains applies the Contains predicate on the "available_for" field (Postgres array contains).
+func AvailableForContains(v string) predicate.ProviderProfile {
+    return predicate.ProviderProfile(func(s *sql.Selector) {
+        // For Postgres, use the @> operator for array contains
+		s.Where(sql.P(func(b *sql.Builder) {
+			b.WriteString(FieldAvailableFor + " @> ARRAY[?]::varchar[]").Arg(v)
+		}))
+    })
 }
 
 // HasUser applies the HasEdge predicate on the "user" edge.

--- a/ent/providerprofile_create.go
+++ b/ent/providerprofile_create.go
@@ -87,20 +87,6 @@ func (ppc *ProviderProfileCreate) SetNillableIsActive(b *bool) *ProviderProfileC
 	return ppc
 }
 
-// SetIsAvailable sets the "is_available" field.
-func (ppc *ProviderProfileCreate) SetIsAvailable(b bool) *ProviderProfileCreate {
-	ppc.mutation.SetIsAvailable(b)
-	return ppc
-}
-
-// SetNillableIsAvailable sets the "is_available" field if the given value is not nil.
-func (ppc *ProviderProfileCreate) SetNillableIsAvailable(b *bool) *ProviderProfileCreate {
-	if b != nil {
-		ppc.SetIsAvailable(*b)
-	}
-	return ppc
-}
-
 // SetUpdatedAt sets the "updated_at" field.
 func (ppc *ProviderProfileCreate) SetUpdatedAt(t time.Time) *ProviderProfileCreate {
 	ppc.mutation.SetUpdatedAt(t)
@@ -238,6 +224,12 @@ func (ppc *ProviderProfileCreate) SetNillableIsKybVerified(b *bool) *ProviderPro
 	if b != nil {
 		ppc.SetIsKybVerified(*b)
 	}
+	return ppc
+}
+
+// SetAvailableFor sets the "available_for" field.
+func (ppc *ProviderProfileCreate) SetAvailableFor(s []string) *ProviderProfileCreate {
+	ppc.mutation.SetAvailableFor(s)
 	return ppc
 }
 
@@ -407,10 +399,6 @@ func (ppc *ProviderProfileCreate) defaults() {
 		v := providerprofile.DefaultIsActive
 		ppc.mutation.SetIsActive(v)
 	}
-	if _, ok := ppc.mutation.IsAvailable(); !ok {
-		v := providerprofile.DefaultIsAvailable
-		ppc.mutation.SetIsAvailable(v)
-	}
 	if _, ok := ppc.mutation.UpdatedAt(); !ok {
 		v := providerprofile.DefaultUpdatedAt()
 		ppc.mutation.SetUpdatedAt(v)
@@ -446,9 +434,6 @@ func (ppc *ProviderProfileCreate) check() error {
 	}
 	if _, ok := ppc.mutation.IsActive(); !ok {
 		return &ValidationError{Name: "is_active", err: errors.New(`ent: missing required field "ProviderProfile.is_active"`)}
-	}
-	if _, ok := ppc.mutation.IsAvailable(); !ok {
-		return &ValidationError{Name: "is_available", err: errors.New(`ent: missing required field "ProviderProfile.is_available"`)}
 	}
 	if _, ok := ppc.mutation.UpdatedAt(); !ok {
 		return &ValidationError{Name: "updated_at", err: errors.New(`ent: missing required field "ProviderProfile.updated_at"`)}
@@ -527,10 +512,6 @@ func (ppc *ProviderProfileCreate) createSpec() (*ProviderProfile, *sqlgraph.Crea
 		_spec.SetField(providerprofile.FieldIsActive, field.TypeBool, value)
 		_node.IsActive = value
 	}
-	if value, ok := ppc.mutation.IsAvailable(); ok {
-		_spec.SetField(providerprofile.FieldIsAvailable, field.TypeBool, value)
-		_node.IsAvailable = value
-	}
 	if value, ok := ppc.mutation.UpdatedAt(); ok {
 		_spec.SetField(providerprofile.FieldUpdatedAt, field.TypeTime, value)
 		_node.UpdatedAt = value
@@ -570,6 +551,10 @@ func (ppc *ProviderProfileCreate) createSpec() (*ProviderProfile, *sqlgraph.Crea
 	if value, ok := ppc.mutation.IsKybVerified(); ok {
 		_spec.SetField(providerprofile.FieldIsKybVerified, field.TypeBool, value)
 		_node.IsKybVerified = value
+	}
+	if value, ok := ppc.mutation.AvailableFor(); ok {
+		_spec.SetField(providerprofile.FieldAvailableFor, field.TypeJSON, value)
+		_node.AvailableFor = value
 	}
 	if nodes := ppc.mutation.UserIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -796,18 +781,6 @@ func (u *ProviderProfileUpsert) UpdateIsActive() *ProviderProfileUpsert {
 	return u
 }
 
-// SetIsAvailable sets the "is_available" field.
-func (u *ProviderProfileUpsert) SetIsAvailable(v bool) *ProviderProfileUpsert {
-	u.Set(providerprofile.FieldIsAvailable, v)
-	return u
-}
-
-// UpdateIsAvailable sets the "is_available" field to the value that was provided on create.
-func (u *ProviderProfileUpsert) UpdateIsAvailable() *ProviderProfileUpsert {
-	u.SetExcluded(providerprofile.FieldIsAvailable)
-	return u
-}
-
 // SetUpdatedAt sets the "updated_at" field.
 func (u *ProviderProfileUpsert) SetUpdatedAt(v time.Time) *ProviderProfileUpsert {
 	u.Set(providerprofile.FieldUpdatedAt, v)
@@ -970,6 +943,24 @@ func (u *ProviderProfileUpsert) UpdateIsKybVerified() *ProviderProfileUpsert {
 	return u
 }
 
+// SetAvailableFor sets the "available_for" field.
+func (u *ProviderProfileUpsert) SetAvailableFor(v []string) *ProviderProfileUpsert {
+	u.Set(providerprofile.FieldAvailableFor, v)
+	return u
+}
+
+// UpdateAvailableFor sets the "available_for" field to the value that was provided on create.
+func (u *ProviderProfileUpsert) UpdateAvailableFor() *ProviderProfileUpsert {
+	u.SetExcluded(providerprofile.FieldAvailableFor)
+	return u
+}
+
+// ClearAvailableFor clears the value of the "available_for" field.
+func (u *ProviderProfileUpsert) ClearAvailableFor() *ProviderProfileUpsert {
+	u.SetNull(providerprofile.FieldAvailableFor)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -1085,20 +1076,6 @@ func (u *ProviderProfileUpsertOne) SetIsActive(v bool) *ProviderProfileUpsertOne
 func (u *ProviderProfileUpsertOne) UpdateIsActive() *ProviderProfileUpsertOne {
 	return u.Update(func(s *ProviderProfileUpsert) {
 		s.UpdateIsActive()
-	})
-}
-
-// SetIsAvailable sets the "is_available" field.
-func (u *ProviderProfileUpsertOne) SetIsAvailable(v bool) *ProviderProfileUpsertOne {
-	return u.Update(func(s *ProviderProfileUpsert) {
-		s.SetIsAvailable(v)
-	})
-}
-
-// UpdateIsAvailable sets the "is_available" field to the value that was provided on create.
-func (u *ProviderProfileUpsertOne) UpdateIsAvailable() *ProviderProfileUpsertOne {
-	return u.Update(func(s *ProviderProfileUpsert) {
-		s.UpdateIsAvailable()
 	})
 }
 
@@ -1288,6 +1265,27 @@ func (u *ProviderProfileUpsertOne) SetIsKybVerified(v bool) *ProviderProfileUpse
 func (u *ProviderProfileUpsertOne) UpdateIsKybVerified() *ProviderProfileUpsertOne {
 	return u.Update(func(s *ProviderProfileUpsert) {
 		s.UpdateIsKybVerified()
+	})
+}
+
+// SetAvailableFor sets the "available_for" field.
+func (u *ProviderProfileUpsertOne) SetAvailableFor(v []string) *ProviderProfileUpsertOne {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.SetAvailableFor(v)
+	})
+}
+
+// UpdateAvailableFor sets the "available_for" field to the value that was provided on create.
+func (u *ProviderProfileUpsertOne) UpdateAvailableFor() *ProviderProfileUpsertOne {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.UpdateAvailableFor()
+	})
+}
+
+// ClearAvailableFor clears the value of the "available_for" field.
+func (u *ProviderProfileUpsertOne) ClearAvailableFor() *ProviderProfileUpsertOne {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.ClearAvailableFor()
 	})
 }
 
@@ -1576,20 +1574,6 @@ func (u *ProviderProfileUpsertBulk) UpdateIsActive() *ProviderProfileUpsertBulk 
 	})
 }
 
-// SetIsAvailable sets the "is_available" field.
-func (u *ProviderProfileUpsertBulk) SetIsAvailable(v bool) *ProviderProfileUpsertBulk {
-	return u.Update(func(s *ProviderProfileUpsert) {
-		s.SetIsAvailable(v)
-	})
-}
-
-// UpdateIsAvailable sets the "is_available" field to the value that was provided on create.
-func (u *ProviderProfileUpsertBulk) UpdateIsAvailable() *ProviderProfileUpsertBulk {
-	return u.Update(func(s *ProviderProfileUpsert) {
-		s.UpdateIsAvailable()
-	})
-}
-
 // SetUpdatedAt sets the "updated_at" field.
 func (u *ProviderProfileUpsertBulk) SetUpdatedAt(v time.Time) *ProviderProfileUpsertBulk {
 	return u.Update(func(s *ProviderProfileUpsert) {
@@ -1776,6 +1760,27 @@ func (u *ProviderProfileUpsertBulk) SetIsKybVerified(v bool) *ProviderProfileUps
 func (u *ProviderProfileUpsertBulk) UpdateIsKybVerified() *ProviderProfileUpsertBulk {
 	return u.Update(func(s *ProviderProfileUpsert) {
 		s.UpdateIsKybVerified()
+	})
+}
+
+// SetAvailableFor sets the "available_for" field.
+func (u *ProviderProfileUpsertBulk) SetAvailableFor(v []string) *ProviderProfileUpsertBulk {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.SetAvailableFor(v)
+	})
+}
+
+// UpdateAvailableFor sets the "available_for" field to the value that was provided on create.
+func (u *ProviderProfileUpsertBulk) UpdateAvailableFor() *ProviderProfileUpsertBulk {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.UpdateAvailableFor()
+	})
+}
+
+// ClearAvailableFor clears the value of the "available_for" field.
+func (u *ProviderProfileUpsertBulk) ClearAvailableFor() *ProviderProfileUpsertBulk {
+	return u.Update(func(s *ProviderProfileUpsert) {
+		s.ClearAvailableFor()
 	})
 }
 

--- a/ent/providerprofile_update.go
+++ b/ent/providerprofile_update.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 	"github.com/google/uuid"
 	"github.com/paycrest/aggregator/ent/apikey"
@@ -99,20 +100,6 @@ func (ppu *ProviderProfileUpdate) SetIsActive(b bool) *ProviderProfileUpdate {
 func (ppu *ProviderProfileUpdate) SetNillableIsActive(b *bool) *ProviderProfileUpdate {
 	if b != nil {
 		ppu.SetIsActive(*b)
-	}
-	return ppu
-}
-
-// SetIsAvailable sets the "is_available" field.
-func (ppu *ProviderProfileUpdate) SetIsAvailable(b bool) *ProviderProfileUpdate {
-	ppu.mutation.SetIsAvailable(b)
-	return ppu
-}
-
-// SetNillableIsAvailable sets the "is_available" field if the given value is not nil.
-func (ppu *ProviderProfileUpdate) SetNillableIsAvailable(b *bool) *ProviderProfileUpdate {
-	if b != nil {
-		ppu.SetIsAvailable(*b)
 	}
 	return ppu
 }
@@ -288,6 +275,24 @@ func (ppu *ProviderProfileUpdate) SetNillableIsKybVerified(b *bool) *ProviderPro
 	if b != nil {
 		ppu.SetIsKybVerified(*b)
 	}
+	return ppu
+}
+
+// SetAvailableFor sets the "available_for" field.
+func (ppu *ProviderProfileUpdate) SetAvailableFor(s []string) *ProviderProfileUpdate {
+	ppu.mutation.SetAvailableFor(s)
+	return ppu
+}
+
+// AppendAvailableFor appends s to the "available_for" field.
+func (ppu *ProviderProfileUpdate) AppendAvailableFor(s []string) *ProviderProfileUpdate {
+	ppu.mutation.AppendAvailableFor(s)
+	return ppu
+}
+
+// ClearAvailableFor clears the value of the "available_for" field.
+func (ppu *ProviderProfileUpdate) ClearAvailableFor() *ProviderProfileUpdate {
+	ppu.mutation.ClearAvailableFor()
 	return ppu
 }
 
@@ -584,9 +589,6 @@ func (ppu *ProviderProfileUpdate) sqlSave(ctx context.Context) (n int, err error
 	if value, ok := ppu.mutation.IsActive(); ok {
 		_spec.SetField(providerprofile.FieldIsActive, field.TypeBool, value)
 	}
-	if value, ok := ppu.mutation.IsAvailable(); ok {
-		_spec.SetField(providerprofile.FieldIsAvailable, field.TypeBool, value)
-	}
 	if value, ok := ppu.mutation.UpdatedAt(); ok {
 		_spec.SetField(providerprofile.FieldUpdatedAt, field.TypeTime, value)
 	}
@@ -637,6 +639,17 @@ func (ppu *ProviderProfileUpdate) sqlSave(ctx context.Context) (n int, err error
 	}
 	if value, ok := ppu.mutation.IsKybVerified(); ok {
 		_spec.SetField(providerprofile.FieldIsKybVerified, field.TypeBool, value)
+	}
+	if value, ok := ppu.mutation.AvailableFor(); ok {
+		_spec.SetField(providerprofile.FieldAvailableFor, field.TypeJSON, value)
+	}
+	if value, ok := ppu.mutation.AppendedAvailableFor(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, providerprofile.FieldAvailableFor, value)
+		})
+	}
+	if ppu.mutation.AvailableForCleared() {
+		_spec.ClearField(providerprofile.FieldAvailableFor, field.TypeJSON)
 	}
 	if ppu.mutation.APIKeyCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -964,20 +977,6 @@ func (ppuo *ProviderProfileUpdateOne) SetNillableIsActive(b *bool) *ProviderProf
 	return ppuo
 }
 
-// SetIsAvailable sets the "is_available" field.
-func (ppuo *ProviderProfileUpdateOne) SetIsAvailable(b bool) *ProviderProfileUpdateOne {
-	ppuo.mutation.SetIsAvailable(b)
-	return ppuo
-}
-
-// SetNillableIsAvailable sets the "is_available" field if the given value is not nil.
-func (ppuo *ProviderProfileUpdateOne) SetNillableIsAvailable(b *bool) *ProviderProfileUpdateOne {
-	if b != nil {
-		ppuo.SetIsAvailable(*b)
-	}
-	return ppuo
-}
-
 // SetUpdatedAt sets the "updated_at" field.
 func (ppuo *ProviderProfileUpdateOne) SetUpdatedAt(t time.Time) *ProviderProfileUpdateOne {
 	ppuo.mutation.SetUpdatedAt(t)
@@ -1149,6 +1148,24 @@ func (ppuo *ProviderProfileUpdateOne) SetNillableIsKybVerified(b *bool) *Provide
 	if b != nil {
 		ppuo.SetIsKybVerified(*b)
 	}
+	return ppuo
+}
+
+// SetAvailableFor sets the "available_for" field.
+func (ppuo *ProviderProfileUpdateOne) SetAvailableFor(s []string) *ProviderProfileUpdateOne {
+	ppuo.mutation.SetAvailableFor(s)
+	return ppuo
+}
+
+// AppendAvailableFor appends s to the "available_for" field.
+func (ppuo *ProviderProfileUpdateOne) AppendAvailableFor(s []string) *ProviderProfileUpdateOne {
+	ppuo.mutation.AppendAvailableFor(s)
+	return ppuo
+}
+
+// ClearAvailableFor clears the value of the "available_for" field.
+func (ppuo *ProviderProfileUpdateOne) ClearAvailableFor() *ProviderProfileUpdateOne {
+	ppuo.mutation.ClearAvailableFor()
 	return ppuo
 }
 
@@ -1475,9 +1492,6 @@ func (ppuo *ProviderProfileUpdateOne) sqlSave(ctx context.Context) (_node *Provi
 	if value, ok := ppuo.mutation.IsActive(); ok {
 		_spec.SetField(providerprofile.FieldIsActive, field.TypeBool, value)
 	}
-	if value, ok := ppuo.mutation.IsAvailable(); ok {
-		_spec.SetField(providerprofile.FieldIsAvailable, field.TypeBool, value)
-	}
 	if value, ok := ppuo.mutation.UpdatedAt(); ok {
 		_spec.SetField(providerprofile.FieldUpdatedAt, field.TypeTime, value)
 	}
@@ -1528,6 +1542,17 @@ func (ppuo *ProviderProfileUpdateOne) sqlSave(ctx context.Context) (_node *Provi
 	}
 	if value, ok := ppuo.mutation.IsKybVerified(); ok {
 		_spec.SetField(providerprofile.FieldIsKybVerified, field.TypeBool, value)
+	}
+	if value, ok := ppuo.mutation.AvailableFor(); ok {
+		_spec.SetField(providerprofile.FieldAvailableFor, field.TypeJSON, value)
+	}
+	if value, ok := ppuo.mutation.AppendedAvailableFor(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, providerprofile.FieldAvailableFor, value)
+		})
+	}
+	if ppuo.mutation.AvailableForCleared() {
+		_spec.ClearField(providerprofile.FieldAvailableFor, field.TypeJSON)
 	}
 	if ppuo.mutation.APIKeyCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/runtime/runtime.go
+++ b/ent/runtime/runtime.go
@@ -270,18 +270,14 @@ func init() {
 	providerprofileDescIsActive := providerprofileFields[4].Descriptor()
 	// providerprofile.DefaultIsActive holds the default value on creation for the is_active field.
 	providerprofile.DefaultIsActive = providerprofileDescIsActive.Default.(bool)
-	// providerprofileDescIsAvailable is the schema descriptor for is_available field.
-	providerprofileDescIsAvailable := providerprofileFields[5].Descriptor()
-	// providerprofile.DefaultIsAvailable holds the default value on creation for the is_available field.
-	providerprofile.DefaultIsAvailable = providerprofileDescIsAvailable.Default.(bool)
 	// providerprofileDescUpdatedAt is the schema descriptor for updated_at field.
-	providerprofileDescUpdatedAt := providerprofileFields[6].Descriptor()
+	providerprofileDescUpdatedAt := providerprofileFields[5].Descriptor()
 	// providerprofile.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	providerprofile.DefaultUpdatedAt = providerprofileDescUpdatedAt.Default.(func() time.Time)
 	// providerprofile.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	providerprofile.UpdateDefaultUpdatedAt = providerprofileDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// providerprofileDescIsKybVerified is the schema descriptor for is_kyb_verified field.
-	providerprofileDescIsKybVerified := providerprofileFields[15].Descriptor()
+	providerprofileDescIsKybVerified := providerprofileFields[14].Descriptor()
 	// providerprofile.DefaultIsKybVerified holds the default value on creation for the is_kyb_verified field.
 	providerprofile.DefaultIsKybVerified = providerprofileDescIsKybVerified.Default.(bool)
 	// providerprofileDescID is the schema descriptor for id field.

--- a/ent/schema/providerprofile.go
+++ b/ent/schema/providerprofile.go
@@ -30,8 +30,6 @@ func (ProviderProfile) Fields() []ent.Field {
 			Default("auto"),
 		field.Bool("is_active").
 			Default(false),
-		field.Bool("is_available").
-			Default(false),
 		field.Time("updated_at").
 			Default(time.Now).
 			UpdateDefault(time.Now),
@@ -50,6 +48,10 @@ func (ProviderProfile) Fields() []ent.Field {
 		field.String("identity_document").Optional(),
 		field.String("business_document").Optional(),
 		field.Bool("is_kyb_verified").Default(false),
+		field.
+			Strings("available_for").
+			Optional().
+			Comment("List of ISO currency codes the provider is available for"),
 	}
 }
 

--- a/scripts/seed-db/main.go
+++ b/scripts/seed-db/main.go
@@ -218,7 +218,7 @@ func seedProvider(ctx context.Context, client *ent.Client, bucket *ent.Provision
 		SetHostIdentifier("http://localhost:8001").
 		SetUser(user).
 		SetIsActive(true).
-		SetIsAvailable(true).
+		SetAvailableFor([]string{currency.Code}). // ADD this line: set available currencies
 		SetAddress("123 Main St").
 		SetMobileNumber("+2348063000000").
 		SetDateOfBirth(time.Date(1990, time.January, 1, 0, 0, 0, 0, time.UTC)).

--- a/services/indexer.go
+++ b/services/indexer.go
@@ -876,7 +876,7 @@ func (s *IndexerService) IndexOrderRefundedTron(ctx context.Context, order *ent.
 				logger.WithFields(logger.Fields{
 					"Error":  fmt.Sprintf("%v", err),
 					"TxHash": order.TxHash,
-				}).Errorf("Failed to fetch event logs for %s", order.Edges.Token.Edges.Network.Identifier)
+				}).Errorf("Failed to fetch trx info by id for %s", order.Edges.Token.Edges.Network.Identifier)
 				return err
 			}
 
@@ -885,7 +885,7 @@ func (s *IndexerService) IndexOrderRefundedTron(ctx context.Context, order *ent.
 				logger.WithFields(logger.Fields{
 					"Error":    fmt.Sprintf("%v", err),
 					"Response": data,
-				}).Errorf("Failed to parse JSON response for %s after fetching event logs", order.Edges.Token.Edges.Network.Identifier)
+				}).Errorf("Failed to parse JSON response for %s", order.Edges.Token.Edges.Network.Identifier)
 				return err
 			}
 
@@ -1123,7 +1123,9 @@ func (s *IndexerService) CreateLockPaymentOrder(ctx context.Context, client type
 				providerordertoken.NetworkEQ(token.Edges.Network.Identifier),
 				providerordertoken.HasProviderWith(
 					providerprofile.IDEQ(lockPaymentOrder.ProviderID),
-					providerprofile.IsAvailableEQ(true),
+					// Remove: providerprofile.IsAvailableEQ(true),
+					// Add: providerprofile.AvailableForContains(institution.Edges.FiatCurrency.Code),
+					providerprofile.AvailableForContains(institution.Edges.FiatCurrency.Code),
 				),
 				providerordertoken.HasTokenWith(tokenEnt.IDEQ(token.ID)),
 				providerordertoken.HasCurrencyWith(
@@ -1136,7 +1138,7 @@ func (s *IndexerService) CreateLockPaymentOrder(ctx context.Context, client type
 		if err != nil {
 			if ent.IsNotFound(err) {
 				// Provider could not be available for several reasons
-				// 1. Provider is not available
+				// 1. Provider is not available for the currency
 				// 2. Provider does not support the token
 				// 3. Provider does not support the network
 				// 4. Provider does not support the currency

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -1342,7 +1342,8 @@ func ComputeMarketRate() error {
 				),
 				providerordertoken.ConversionRateTypeEQ(providerordertoken.ConversionRateTypeFixed),
 				providerordertoken.HasProviderWith(
-					providerprofile.IsAvailableEQ(true),
+					// providerprofile.IsAvailableEQ(true), // REMOVE this line
+					providerprofile.AvailableForContains(currency.Code), // ADD this line
 				),
 			).
 			Select(providerordertoken.FieldFixedConversionRate).

--- a/types/types.go
+++ b/types/types.go
@@ -252,7 +252,7 @@ type ProviderProfilePayload struct {
 	TradingName          string                      `json:"tradingName"`
 	Currencies           []string                    `json:"currencies"`
 	HostIdentifier       string                      `json:"hostIdentifier"`
-	IsAvailable          bool                        `json:"isAvailable"`
+	AvailableFor         []string                    `json:"availableFor"` // ISO currency codes
 	Tokens               []ProviderOrderTokenPayload `json:"tokens"`
 	VisibilityMode       string                      `json:"visibilityMode"`
 	Address              string                      `json:"address"`
@@ -273,7 +273,7 @@ type ProviderProfileResponse struct {
 	TradingName          string                               `json:"tradingName"`
 	Currencies           []string                             `json:"currencies"`
 	HostIdentifier       string                               `json:"hostIdentifier"`
-	IsAvailable          bool                                 `json:"isAvailable"`
+	AvailableFor         []string                             `json:"availableFor"` // ISO currency codes
 	Tokens               []ProviderOrderTokenPayload          `json:"tokens"`
 	APIKey               APIKeyResponse                       `json:"apiKey"`
 	IsActive             bool                                 `json:"isActive"`

--- a/utils/test/db.go
+++ b/utils/test/db.go
@@ -457,7 +457,7 @@ func CreateTestProviderProfile(overrides map[string]interface{}) (*ent.ProviderP
 		"provision_mode":  "auto",
 		"is_partner":      false,
 		"visibility_mode": "public",
-		"is_available":    true,
+		"available_for":   []string{"USD"}, // <-- Use available_for instead of is_available
 	}
 
 	// Apply overrides
@@ -474,7 +474,8 @@ func CreateTestProviderProfile(overrides map[string]interface{}) (*ent.ProviderP
 		SetUserID(payload["user_id"].(uuid.UUID)).
 		AddCurrencyIDs(payload["currency_id"].(uuid.UUID)).
 		SetVisibilityMode(providerprofile.VisibilityMode(payload["visibility_mode"].(string))).
-		SetIsAvailable(payload["is_available"].(bool)).
+		// .SetIsAvailable(payload["is_available"].(bool)). // REMOVE this line
+		SetAvailableFor(payload["available_for"].([]string)). // ADD this line
 		Save(context.Background())
 
 	return profile, err


### PR DESCRIPTION
### Description

This PR updates the test utilities to support the new provider availability model, as part of the migration from a boolean `is_available` field to a currency-specific `available_for` array. All test helpers and test data creation now use `available_for` (an array of ISO currency codes) to set and assert provider availability. This aligns the test setup with the new business logic, ensuring that providers can be tested for availability on a per-currency basis.

**Key changes:**
- Removes all usage of `IsAvailable` and the `is_available` field from test helpers.
- Adds and uses `AvailableFor` and the `available_for` field for currency-specific provider availability.
- Updates the default payloads and test assertions to use `available_for` as an array of ISO currency codes.
- Ensures all test data and assertions reflect the new provider availability model.

This change is required for the new matching logic and API, and ensures that tests accurately reflect the updated provider profile structure.

### References

- Closes #476

### Testing

- All unit and integration tests have been updated to use the new `available_for` field.
- Manual testing: 
  - Run all tests to ensure they pass with the new provider availability logic.
  - Verify that test providers can be created with specific available currencies and that this is reflected in test assertions.
- Developed and tested on Go 1.21, Postgres 14, MacOS 14, and Docker Compose environment.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).