### PR TITLE
feat: add index block range endpoint for manual blockchain indexing

### DIFF
--- a/routers/index.go
+++ b/routers/index.go
@@ -43,6 +43,9 @@ func RegisterRoutes(route *gin.Engine) {
 	v1.POST("verify-account", ctrl.VerifyAccount)
 	v1.GET("orders/:chain_id/:id", ctrl.GetLockPaymentOrderStatus)
 
+	// Index block range endpoint
+	v1.POST("index-block-range", ctrl.IndexBlockRange)
+
 	// KYC routes
 	v1.POST("kyc", ctrl.RequestIDVerification)
 	v1.GET("kyc/:wallet_address", ctrl.GetIDVerificationStatus)

--- a/services/indexer/evm.go
+++ b/services/indexer/evm.go
@@ -36,7 +36,7 @@ func NewIndexerEVM() types.Indexer {
 }
 
 // IndexTransfer indexes transfers to the receive address for EVM networks.
-func (s *IndexerEVM) IndexTransfer(ctx context.Context, rpcClient types.RPCClient, token *ent.Token, fromBlock int64, toBlock int64) error {
+func (s *IndexerEVM) IndexTransfer(ctx context.Context, token *ent.Token, address string, fromBlock int64, toBlock int64) error {
 	// Get Transfer event data
 	payload := map[string]string{
 		"filter_block_number_gte": fmt.Sprintf("%d", fromBlock),
@@ -46,6 +46,10 @@ func (s *IndexerEVM) IndexTransfer(ctx context.Context, rpcClient types.RPCClien
 		"sort_order":              "desc",
 		"decode":                  "true",
 		"limit":                   "500",
+	}
+
+	if address != "" {
+		payload["filter_topic_2"] = address
 	}
 
 	events, err := s.engineService.GetContractEvents(ctx, token.Edges.Network.ChainID, token.ContractAddress, payload)
@@ -100,7 +104,7 @@ func (s *IndexerEVM) IndexTransfer(ctx context.Context, rpcClient types.RPCClien
 }
 
 // IndexOrderCreated indexes orders created in the Gateway contract for EVM networks.
-func (s *IndexerEVM) IndexOrderCreated(ctx context.Context, rpcClient types.RPCClient, network *ent.Network, fromBlock int64, toBlock int64) error {
+func (s *IndexerEVM) IndexOrderCreated(ctx context.Context, network *ent.Network, fromBlock int64, toBlock int64) error {
 	// Get OrderCreated event data
 	eventPayload := map[string]string{
 		"filter_block_number_gte": fmt.Sprintf("%d", fromBlock),
@@ -168,7 +172,7 @@ func (s *IndexerEVM) IndexOrderCreated(ctx context.Context, rpcClient types.RPCC
 }
 
 // IndexOrderSettled indexes orders settled in the Gateway contract for EVM networks.
-func (s *IndexerEVM) IndexOrderSettled(ctx context.Context, rpcClient types.RPCClient, network *ent.Network, fromBlock int64, toBlock int64) error {
+func (s *IndexerEVM) IndexOrderSettled(ctx context.Context, network *ent.Network, fromBlock int64, toBlock int64) error {
 	// Get OrderSettled event data
 	eventPayload := map[string]string{
 		"filter_block_number_gte": fmt.Sprintf("%d", fromBlock),
@@ -225,7 +229,7 @@ func (s *IndexerEVM) IndexOrderSettled(ctx context.Context, rpcClient types.RPCC
 }
 
 // IndexOrderRefunded indexes orders settled in the Gateway contract for EVM networks.
-func (s *IndexerEVM) IndexOrderRefunded(ctx context.Context, rpcClient types.RPCClient, network *ent.Network, fromBlock int64, toBlock int64) error {
+func (s *IndexerEVM) IndexOrderRefunded(ctx context.Context, network *ent.Network, fromBlock int64, toBlock int64) error {
 	// Get OrderRefunded event data
 	eventPayload := map[string]string{
 		"filter_block_number_gte": fmt.Sprintf("%d", fromBlock),

--- a/services/indexer/tron.go
+++ b/services/indexer/tron.go
@@ -42,7 +42,7 @@ func NewIndexerTron() types.Indexer {
 }
 
 // IndexTransfer indexes transfers to the receive address for Tron network.
-func (s *IndexerTron) IndexTransfer(ctx context.Context, rpcClient types.RPCClient, token *ent.Token, fromBlock int64, toBlock int64) error {
+func (s *IndexerTron) IndexTransfer(ctx context.Context, token *ent.Token, address string, fromBlock int64, toBlock int64) error {
 	res, err := fastshot.NewClient(token.Edges.Network.RPCEndpoint).
 		Config().SetTimeout(15 * time.Second).
 		Build().GET(fmt.Sprintf("/v1/contracts/%s/events", token.ContractAddress)).
@@ -105,7 +105,7 @@ func (s *IndexerTron) IndexTransfer(ctx context.Context, rpcClient types.RPCClie
 }
 
 // IndexOrderCreated indexes orders created in the Gateway contract for the Tron network.
-func (s *IndexerTron) IndexOrderCreated(ctx context.Context, rpcClient types.RPCClient, network *ent.Network, fromBlock int64, toBlock int64) error {
+func (s *IndexerTron) IndexOrderCreated(ctx context.Context, network *ent.Network, fromBlock int64, toBlock int64) error {
 	res, err := fastshot.NewClient(network.RPCEndpoint).
 		Config().SetTimeout(15 * time.Second).
 		Build().GET(fmt.Sprintf("/v1/contracts/%s/events", network.GatewayContractAddress)).
@@ -196,7 +196,7 @@ func (s *IndexerTron) IndexOrderCreated(ctx context.Context, rpcClient types.RPC
 }
 
 // IndexOrderSettled indexes orders settled in the Gateway contract for the Tron network.
-func (s *IndexerTron) IndexOrderSettled(ctx context.Context, rpcClient types.RPCClient, network *ent.Network, fromBlock int64, toBlock int64) error {
+func (s *IndexerTron) IndexOrderSettled(ctx context.Context, network *ent.Network, fromBlock int64, toBlock int64) error {
 	res, err := fastshot.NewClient(network.RPCEndpoint).
 		Config().SetTimeout(15 * time.Second).
 		Build().GET(fmt.Sprintf("/v1/contracts/%s/events", network.GatewayContractAddress)).
@@ -285,7 +285,7 @@ func (s *IndexerTron) IndexOrderSettled(ctx context.Context, rpcClient types.RPC
 }
 
 // IndexOrderRefunded indexes orders settled in the Gateway contract for the Tron network.
-func (s *IndexerTron) IndexOrderRefunded(ctx context.Context, rpcClient types.RPCClient, network *ent.Network, fromBlock int64, toBlock int64) error {
+func (s *IndexerTron) IndexOrderRefunded(ctx context.Context, network *ent.Network, fromBlock int64, toBlock int64) error {
 	res, err := fastshot.NewClient(network.RPCEndpoint).
 		Config().SetTimeout(15 * time.Second).
 		Build().GET(fmt.Sprintf("/v1/contracts/%s/events", network.GatewayContractAddress)).

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -279,12 +279,12 @@ func runIndexers(network *ent.Network, indexer types.Indexer, tokens []*ent.Toke
 	// Index Gateway events
 	go func(network *ent.Network, indexer types.Indexer, start, end int64) {
 		ctx := context.Background()
-		_ = indexer.IndexOrderCreated(ctx, nil, network, start, end)
+		_ = indexer.IndexOrderCreated(ctx, network, start, end)
 	}(network, indexer, startBlock, latestBlock)
 
 	go func(network *ent.Network, indexer types.Indexer, start, end int64) {
 		ctx := context.Background()
-		err := indexer.IndexOrderSettled(ctx, nil, network, start, end)
+		err := indexer.IndexOrderSettled(ctx, network, start, end)
 		if err != nil {
 			logger.WithFields(logger.Fields{
 				"Error": fmt.Sprintf("%v", err),
@@ -294,7 +294,7 @@ func runIndexers(network *ent.Network, indexer types.Indexer, tokens []*ent.Toke
 
 	go func(network *ent.Network, indexer types.Indexer, start, end int64) {
 		ctx := context.Background()
-		_ = indexer.IndexOrderRefunded(ctx, nil, network, start, end)
+		_ = indexer.IndexOrderRefunded(ctx, network, start, end)
 	}(network, indexer, startBlock, latestBlock)
 
 	// Index transfer events for tokens in this network
@@ -305,7 +305,7 @@ func runIndexers(network *ent.Network, indexer types.Indexer, tokens []*ent.Toke
 
 		go func(token *ent.Token, indexer types.Indexer, start, end int64) {
 			ctx := context.Background()
-			_ = indexer.IndexTransfer(ctx, nil, token, start, end)
+			_ = indexer.IndexTransfer(ctx, token, "", start, end)
 		}(token, indexer, startBlock, latestBlock)
 	}
 }
@@ -884,8 +884,8 @@ func FixDatabaseMishap() error {
 
 	indexerInstance := indexer.NewIndexerEVM()
 
-	_ = indexerInstance.IndexOrderCreated(ctx, nil, network, 18052684, 18052684)
-	_ = indexerInstance.IndexOrderCreated(ctx, nil, network, 18056857, 18056857)
+	_ = indexerInstance.IndexOrderCreated(ctx, network, 18052684, 18052684)
+	_ = indexerInstance.IndexOrderCreated(ctx, network, 18056857, 18056857)
 
 	return nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -104,10 +104,10 @@ type OrderService interface {
 
 // Indexer provides an interface for indexing blockchain data to the database.
 type Indexer interface {
-	IndexTransfer(ctx context.Context, rpcClient RPCClient, token *ent.Token, fromBlock int64, toBlock int64) error
-	IndexOrderCreated(ctx context.Context, rpcClient RPCClient, network *ent.Network, fromBlock int64, toBlock int64) error
-	IndexOrderSettled(ctx context.Context, rpcClient RPCClient, network *ent.Network, fromBlock int64, toBlock int64) error
-	IndexOrderRefunded(ctx context.Context, rpcClient RPCClient, network *ent.Network, fromBlock int64, toBlock int64) error
+	IndexTransfer(ctx context.Context, token *ent.Token, address string, fromBlock int64, toBlock int64) error
+	IndexOrderCreated(ctx context.Context, network *ent.Network, fromBlock int64, toBlock int64) error
+	IndexOrderSettled(ctx context.Context, network *ent.Network, fromBlock int64, toBlock int64) error
+	IndexOrderRefunded(ctx context.Context, network *ent.Network, fromBlock int64, toBlock int64) error
 }
 
 // KYCProvider defines the interface for KYC verification providers
@@ -692,4 +692,23 @@ type SupportedTokenResponse struct {
 	Decimals        int8   `json:"decimals"`
 	BaseCurrency    string `json:"baseCurrency"`
 	Network         string `json:"network"`
+}
+
+// IndexBlockRangeRequest represents the request payload for indexing a specific block range
+type IndexBlockRangeRequest struct {
+	FromBlock int64  `json:"fromBlock" binding:"required,min=0"`
+	ToBlock   int64  `json:"toBlock" binding:"required,min=0"`
+	Network   string `json:"network" binding:"required"`
+	Address   string `json:"address"` // Optional, only required for Transfer indexing if available
+}
+
+// IndexBlockRangeResponse represents the response for the index block range endpoint
+type IndexBlockRangeResponse struct {
+	Message string `json:"message"`
+	Events  struct {
+		Transfer      int `json:"Transfer"`
+		OrderCreated  int `json:"OrderCreated"`
+		OrderSettled  int `json:"OrderSettled"`
+		OrderRefunded int `json:"OrderRefunded"`
+	} `json:"events"`
 }


### PR DESCRIPTION
### Description

This PR adds a new endpoint for manual blockchain indexing that allows developers and operators to index specific block ranges for debugging, backfilling, and testing purposes.

**Key Features:**
- **New Endpoint**: `POST /v1/index-block-range` for manual indexing of specific block ranges
- **Event Types**: Supports indexing of Transfer, OrderCreated, OrderSettled, and OrderRefunded events
- **Parallel Processing**: Each event type runs in separate goroutines for optimal performance
- **Network Support**: Automatically handles both EVM networks (base, lisk, arbitrum-one, bsc) and Tron networks
- **Comprehensive Validation**: Block range limits (max 1000 blocks), network validation, and environment-aware filtering
- **Optional Address Filtering**: Supports filtering Transfer events by specific addresses

**Use Cases:**
- **Backfilling**: Index historical blocks that may have been missed during normal operation
- **Debugging**: Re-index specific blocks to investigate issues or verify data integrity
- **Testing**: Manual indexing for development and testing scenarios
- **Recovery**: Re-process blocks after system issues or data inconsistencies

**Technical Implementation:**
- Updated Indexer interface to remove unused RPCClient parameter for cleaner API
- Added proper error handling and structured logging for all indexing operations
- Implemented environment-aware network validation (testnet vs production)
- Added request/response types with proper validation rules
- Integrated seamlessly with existing indexing infrastructure

**API Specification:**
```json
// Request
POST /v1/index-block-range
{
  "fromBlock": 1000000,
  "toBlock": 1000100,
  "network": "base",
  "address": "0x1234..." // Optional
}

// Response
{
  "status": "success",
  "message": "Block range indexing completed",
  "data": {
    "message": "Successfully indexed block range 1000000 to 1000100 for network base",
    "events": {
      "Transfer": 1,
      "OrderCreated": 1,
      "OrderSettled": 1,
      "OrderRefunded": 1
    }
  }
}
```

### References

This feature addresses the need for manual blockchain indexing capabilities that were previously only available through the automated cron job system. It provides operators with more control over the indexing process and enables better debugging and recovery workflows.

### Testing

**Manual Testing Steps:**
1. Start the aggregator server: `make run`
2. Test valid request:
   ```bash
   curl -X POST http://localhost:8000/v1/index-block-range \
     -H "Content-Type: application/json" \
     -d '{"fromBlock": 1000000, "toBlock": 1000100, "network": "base"}'
   ```
3. Test validation errors:
   - Block range > 1000 blocks
   - Invalid network identifier
   - fromBlock >= toBlock
   - Missing required fields

**Environment:**
- Language: Go 1.23.0
- Framework: Gin
- Database: PostgreSQL with Ent ORM
- Networks: EVM (base, lisk, arbitrum-one, bsc) and Tron

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation and tests for new/changed/fixed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing (Note: Some existing tests are failing due to unrelated issues in the codebase)
- [x] The correct base branch is being used (stable)

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a). 