### PR TITLE
fix: improve Etherscan error grouping in Glitchtip

### DIFF
--- a/services/etherscan.go
+++ b/services/etherscan.go
@@ -506,7 +506,10 @@ func (w *EtherscanWorker) processNextRequest(ctx context.Context) error {
 				"WorkerID":  w.WorkerID,
 				"RequestID": request.ID,
 				"ErrorType": errorType,
-			}).Errorf("API error occurred: %v", err)
+				"ChainID":   request.ChainID,
+				"Address":   request.WalletAddress,
+				"Error":     err.Error(),
+			}).Errorf("Etherscan API error for chain %d", request.ChainID)
 		case ErrorTypeNetwork:
 			// Network errors are usually temporary
 			atomic.AddInt64(&networkErrorsCounter, 1)
@@ -521,7 +524,10 @@ func (w *EtherscanWorker) processNextRequest(ctx context.Context) error {
 				"WorkerID":  w.WorkerID,
 				"RequestID": request.ID,
 				"ErrorType": errorType,
-			}).Errorf("Unknown error occurred: %v", err)
+				"ChainID":   request.ChainID,
+				"Address":   request.WalletAddress,
+				"Error":     err.Error(),
+			}).Errorf("Etherscan unknown error for chain %d", request.ChainID)
 		}
 	}
 


### PR DESCRIPTION
- Move wallet address from error message to log fields for better grouping
- Standardize error messages to group by chain ID and error type
- Only modify Errorf calls, keeping warnings unchanged
- Error details still available in log fields for debugging

This fixes the issue where each unique wallet address created separate error groups in Glitchtip monitoring dashboard.
<img width="914" height="273" alt="Screenshot 2025-09-17 095025" src="https://github.com/user-attachments/assets/cb9b012d-3c0c-4043-8a80-91f8a24bb387" />

### Description
This fixes the issue where each unique wallet address created separate error groups in the Glitchtip monitoring dashboard.


### References

> - GitHub Issue/PR number addressed or fixed e.g closes #524


### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this project has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [ ] I have added documentation and tests for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`


By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
