### PR TITLE
feat: add validation for Paycrest terms agreement in KYB submission

### DIFF
--- a/controllers/index.go
+++ b/controllers/index.go
@@ -1514,6 +1514,15 @@ func (ctrl *Controller) HandleKYBSubmission(ctx *gin.Context) {
 		return
 	}
 
+	// Validate that user has agreed to Paycrest terms
+	if !input.IAgreeToPaycrestTerms {
+		logger.WithFields(logger.Fields{
+			"IAgreeToPaycrestTerms": input.IAgreeToPaycrestTerms,
+		}).Errorf("Error: User has not agreed to Paycrest terms")
+		u.APIResponse(ctx, http.StatusBadRequest, "error", "You must agree to Paycrest terms and conditions to proceed", nil)
+		return
+	}
+
 	// Get user ID from the context
 	userIDValue, exists := ctx.Get("user_id")
 	if !exists {

--- a/types/types.go
+++ b/types/types.go
@@ -709,6 +709,7 @@ type KYBSubmissionInput struct {
 	AmlPolicyUrl                  *string                `json:"amlPolicyUrl"`
 	KycPolicyUrl                  *string                `json:"kycPolicyUrl"`
 	BeneficialOwners              []BeneficialOwnerInput `json:"beneficialOwners" binding:"required,dive"`
+	IAgreeToPaycrestTerms         bool                   `json:"iAgreeToPaycrestTerms"`
 }
 
 // BeneficialOwnerInput represents the input structure for a beneficial owner


### PR DESCRIPTION
### Description
This pull request adds a new requirement that users must explicitly agree to Paycrest terms and conditions before submitting a KYB (Know Your Business) application. The change is enforced at both the API validation and test levels. The most important changes are grouped below:

**Validation Logic Updates:**

* Added a check in the `HandleKYBSubmission` controller to ensure `IAgreeToPaycrestTerms` is true; otherwise, the submission is rejected with a clear error message.

**API Input Updates:**

* Added a new boolean field `IAgreeToPaycrestTerms` to the `KYBSubmissionInput` struct in `types/types.go` to capture user agreement.


### Testing

* Updated existing tests to include the `IAgreeToPaycrestTerms` field, ensuring that valid submissions set it to true. [[1]](diffhunk://#diff-0189cbc73bf5d724e9b1c6e2fc9d1b5b55a60e2095b00ecccc9213ba55195331R386) [[2]](diffhunk://#diff-0189cbc73bf5d724e9b1c6e2fc9d1b5b55a60e2095b00ecccc9213ba55195331R557)
* Added and updated test cases to verify that submissions without agreement to terms are rejected with the correct error message and status code. [[1]](diffhunk://#diff-0189cbc73bf5d724e9b1c6e2fc9d1b5b55a60e2095b00ecccc9213ba55195331R682) [[2]](diffhunk://#diff-0189cbc73bf5d724e9b1c6e2fc9d1b5b55a60e2095b00ecccc9213ba55195331R701-R723)

- [x] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [x] I have added documentation and tests for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing

By submitting a PR, I agree to Paycrest's [Contributor Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c) and [Contribution Guide](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a).
